### PR TITLE
[FIX/#11] Typography lineheight 수정

### DIFF
--- a/app/src/main/java/org/sopt/mcdonalds/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/core/designsystem/theme/Type.kt
@@ -53,11 +53,13 @@ private fun McDonaldsTextStyle(
 fun McDonaldsTypography() = McDonaldsTypography(
     head34b = McDonaldsTextStyle(
         fontFamily = PretendardBold,
-        fontSize = 34.sp
+        fontSize = 34.sp,
+        lineHeight = 40.sp
     ),
     head24sb = McDonaldsTextStyle(
         fontFamily = PretendardSemiBold,
-        fontSize = 24.sp
+        fontSize = 24.sp,
+        lineHeight = 22.sp
     ),
     head18b = McDonaldsTextStyle(
         fontFamily = PretendardBold,
@@ -65,27 +67,31 @@ fun McDonaldsTypography() = McDonaldsTypography(
     ),
     body18m = McDonaldsTextStyle(
         fontFamily = PretendardMedium,
-        fontSize = 18.sp
+        fontSize = 18.sp,
+        lineHeight = 22.sp
     ),
     body16sb = McDonaldsTextStyle(
         fontFamily = PretendardSemiBold,
-        fontSize = 16.sp
+        fontSize = 16.sp,
     ),
     body16m = McDonaldsTextStyle(
         fontFamily = PretendardMedium,
-        fontSize = 16.sp
+        fontSize = 16.sp,
     ),
     body16r = McDonaldsTextStyle(
         fontFamily = PretendardRegular,
-        fontSize = 16.sp
+        fontSize = 16.sp,
+        lineHeight = 22.sp,
     ),
     body14b = McDonaldsTextStyle(
         fontFamily = PretendardBold,
-        fontSize = 14.sp
+        fontSize = 14.sp,
+        lineHeight = 22.sp,
     ),
     body14m = McDonaldsTextStyle(
         fontFamily = PretendardMedium,
-        fontSize = 14.sp
+        fontSize = 14.sp,
+        lineHeight = 22.sp
     ),
     body14r = McDonaldsTextStyle(
         fontFamily = PretendardRegular,
@@ -93,15 +99,18 @@ fun McDonaldsTypography() = McDonaldsTypography(
     ),
     body12m = McDonaldsTextStyle(
         fontFamily = PretendardMedium,
-        fontSize = 12.sp
+        fontSize = 12.sp,
+        lineHeight = 22.sp,
     ),
     body12r = McDonaldsTextStyle(
         fontFamily = PretendardRegular,
-        fontSize = 12.sp
+        fontSize = 12.sp,
+        lineHeight = 22.sp
     ),
     caption10r = McDonaldsTextStyle(
         fontFamily = PretendardRegular,
-        fontSize = 10.sp
+        fontSize = 10.sp,
+        lineHeight = 22.sp
     )
 )
 


### PR DESCRIPTION
## Related issue 🛠
- closed #11

## Work Description ✏️
- 디자인 시스템에 맞게 LineHeight 수정했습니다.

## Screenshot 📸
<img width="360" alt="스크린샷 2025-05-14 오후 3 02 49" src="https://github.com/user-attachments/assets/a91d3efe-2aff-4696-9985-8e18d6b56047" />

## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢
디자인 시스템에 줄간격을 적용하지 않으니까 피그마랑 다르더라구요 그래서 적용했습니다.
모든 Typography를 사용하지 않기에 또 피그마랑 LineHeight가 다른 상황이 발생할 수 있지만....
그 때는 그냥 직접 설정해주는걸로 해요..ㅎㅎ