### PR TITLE
[UI/#10] 주문내역 페이지 개별 컴포넌트 구현

### DIFF
--- a/app/src/main/java/org/sopt/mcdonalds/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/core/designsystem/theme/Type.kt
@@ -72,21 +72,21 @@ fun McDonaldsTypography() = McDonaldsTypography(
     ),
     body16sb = McDonaldsTextStyle(
         fontFamily = PretendardSemiBold,
-        fontSize = 16.sp,
+        fontSize = 16.sp
     ),
     body16m = McDonaldsTextStyle(
         fontFamily = PretendardMedium,
-        fontSize = 16.sp,
+        fontSize = 16.sp
     ),
     body16r = McDonaldsTextStyle(
         fontFamily = PretendardRegular,
         fontSize = 16.sp,
-        lineHeight = 22.sp,
+        lineHeight = 22.sp
     ),
     body14b = McDonaldsTextStyle(
         fontFamily = PretendardBold,
         fontSize = 14.sp,
-        lineHeight = 22.sp,
+        lineHeight = 22.sp
     ),
     body14m = McDonaldsTextStyle(
         fontFamily = PretendardMedium,
@@ -100,7 +100,7 @@ fun McDonaldsTypography() = McDonaldsTypography(
     body12m = McDonaldsTextStyle(
         fontFamily = PretendardMedium,
         fontSize = 12.sp,
-        lineHeight = 22.sp,
+        lineHeight = 22.sp
     ),
     body12r = McDonaldsTextStyle(
         fontFamily = PretendardRegular,

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
@@ -50,7 +50,7 @@ fun HistoryMenuAddButton(
 
 @Preview
 @Composable
-fun HistoryMenuAddButtonPreview() {
+private fun HistoryMenuAddButtonPreview() {
     MCDONALDSTheme {
         HistoryMenuAddButton(
             text = "+ 메뉴 추가",

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
@@ -1,36 +1,37 @@
 package org.sopt.mcdonalds.presentation.history.component
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
 import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
+/**
+ * 주문내역 페이지 속에서 메뉴 추가를 위해 사용하는 버튼
+ *
+ * @param text 버튼에 표시할 텍스트입니다.
+ * @param onClick 버튼 클릭 시 발생할 이벤트 함수입니다.
+ * @param modifier 수정자
+ */
 @Composable
 fun HistoryMenuAddButton(
     text: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     Text(
         modifier = modifier
             .background(
                 color = McDonaldsTheme.colors.white,
-                shape = RoundedCornerShape(20.dp),
+                shape = RoundedCornerShape(20.dp)
             )
             .border(
                 width = 1.dp,
@@ -43,19 +44,18 @@ fun HistoryMenuAddButton(
         style = McDonaldsTheme.typography.body12r,
         color = McDonaldsTheme.colors.black,
         maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
+        overflow = TextOverflow.Ellipsis
     )
 }
 
 @Preview
 @Composable
-fun HistoryMenuAddButtonPreview(
-){
+fun HistoryMenuAddButtonPreview() {
     MCDONALDSTheme {
         HistoryMenuAddButton(
             text = "+ 메뉴 추가",
             onClick = {},
-            modifier = Modifier,
+            modifier = Modifier
         )
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
@@ -1,0 +1,59 @@
+package org.sopt.mcdonalds.presentation.history.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+
+@Composable
+fun HistoryMenuAddButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier,
+    enabled: Boolean = true,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        border = BorderStroke(1.dp, McDonaldsTheme.colors.gray400),
+        colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.white),
+        shape = RoundedCornerShape(20.dp),
+        contentPadding = PaddingValues(0.dp),
+        interactionSource = NoRippleInteractionSource,
+    ) {
+        Text(
+            text = text,
+            style = McDonaldsTheme.typography.body12r,
+            color = McDonaldsTheme.colors.black,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HistoryMenuAddButtonPreview(
+){
+    MCDONALDSTheme {
+        HistoryMenuAddButton(
+            text = "+ 메뉴 추가",
+            onClick = {},
+            modifier = Modifier.size(width = 106.dp, height = 38.dp),
+            enabled = true,
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
@@ -21,12 +21,13 @@ import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 fun HistoryMenuAddButton(
     text: String,
     onClick: () -> Unit,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
     Button(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier
+            .padding(10.dp),
         enabled = enabled,
         border = BorderStroke(1.dp, McDonaldsTheme.colors.gray400),
         colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.white),

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryMenuAddButton.kt
@@ -1,6 +1,8 @@
 package org.sopt.mcdonalds.presentation.history.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -14,6 +16,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
+import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
@@ -22,27 +25,26 @@ fun HistoryMenuAddButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
 ) {
-    Button(
-        onClick = onClick,
+    Text(
         modifier = modifier
-            .padding(10.dp),
-        enabled = enabled,
-        border = BorderStroke(1.dp, McDonaldsTheme.colors.gray400),
-        colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.white),
-        shape = RoundedCornerShape(20.dp),
-        contentPadding = PaddingValues(0.dp),
-        interactionSource = NoRippleInteractionSource,
-    ) {
-        Text(
-            text = text,
-            style = McDonaldsTheme.typography.body12r,
-            color = McDonaldsTheme.colors.black,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
+            .background(
+                color = McDonaldsTheme.colors.white,
+                shape = RoundedCornerShape(20.dp),
+            )
+            .border(
+                width = 1.dp,
+                color = McDonaldsTheme.colors.gray400,
+                shape = RoundedCornerShape(20.dp)
+            )
+            .padding(start = 25.dp, end = 25.dp, top = 10.dp, bottom = 10.dp)
+            .noRippleClickable(onClick),
+        text = text,
+        style = McDonaldsTheme.typography.body12r,
+        color = McDonaldsTheme.colors.black,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
 }
 
 @Preview
@@ -53,8 +55,7 @@ fun HistoryMenuAddButtonPreview(
         HistoryMenuAddButton(
             text = "+ 메뉴 추가",
             onClick = {},
-            modifier = Modifier.size(width = 106.dp, height = 38.dp),
-            enabled = true,
+            modifier = Modifier,
         )
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
@@ -52,7 +52,6 @@ fun HistoryResultBar(
             )
         }
     }
-
 }
 
 @Composable

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
@@ -1,0 +1,93 @@
+package org.sopt.mcdonalds.presentation.history.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import java.text.DecimalFormat
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+
+@Composable
+fun HistoryResultBar(
+    text: String,
+    amount: Int,
+    modifier: Modifier,
+) {
+    TopShadow(
+        modifier = Modifier
+    )
+    {
+        Row (
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = McDonaldsTheme.colors.white)
+                .padding(start = 20.dp, end = 20.dp, top = 25.dp, bottom = 25.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = text,
+                style = McDonaldsTheme.typography.body16sb,
+                color = McDonaldsTheme.colors.black,
+            )
+            Text(
+                text = "₩" + DecimalFormat("#,###").format(amount),
+                style = McDonaldsTheme.typography.body18m,
+                color = McDonaldsTheme.colors.black,
+            )
+        }
+    }
+
+}
+
+@Composable
+fun TopShadow(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(5.dp)
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.1f))
+                    )
+                )
+        )
+        content()
+    }
+}
+
+@Preview
+@Composable
+fun HistoryResultBarPreview(){
+    MCDONALDSTheme {
+        Column {
+            HistoryResultBar(
+                text = "주문 금액",
+                amount = 11500,
+                modifier = Modifier,
+            )
+        }
+
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
@@ -8,12 +8,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,33 +20,39 @@ import java.text.DecimalFormat
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
+/**
+ * 주문내역 페이지 속에서 최종 금액 표시를 위한 바
+ *
+ * @param text 바에 표시할 텍스트입니다.
+ * @param amount 바에 표시할 최종 금액입니다.
+ * @param modifier 수정자
+ */
 @Composable
 fun HistoryResultBar(
     text: String,
     amount: Int,
-    modifier: Modifier,
+    modifier: Modifier
 ) {
     TopShadow(
         modifier = Modifier
-    )
-    {
-        Row (
+    ) {
+        Row(
             modifier = modifier
                 .fillMaxWidth()
                 .background(color = McDonaldsTheme.colors.white)
                 .padding(start = 20.dp, end = 20.dp, top = 25.dp, bottom = 25.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
                 text = text,
                 style = McDonaldsTheme.typography.body16sb,
-                color = McDonaldsTheme.colors.black,
+                color = McDonaldsTheme.colors.black
             )
             Text(
                 text = "₩" + DecimalFormat("#,###").format(amount),
                 style = McDonaldsTheme.typography.body18m,
-                color = McDonaldsTheme.colors.black,
+                color = McDonaldsTheme.colors.black
             )
         }
     }
@@ -60,7 +64,7 @@ fun TopShadow(
     content: @Composable () -> Unit
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier
     ) {
         Box(
             modifier = Modifier
@@ -78,15 +82,14 @@ fun TopShadow(
 
 @Preview
 @Composable
-fun HistoryResultBarPreview(){
+fun HistoryResultBarPreview() {
     MCDONALDSTheme {
         Column {
             HistoryResultBar(
                 text = "주문 금액",
                 amount = 11500,
-                modifier = Modifier,
+                modifier = Modifier
             )
         }
-
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
@@ -31,7 +31,7 @@ import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 fun HistoryResultBar(
     text: String,
     amount: Int,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     TopShadow(
         modifier = Modifier
@@ -59,7 +59,7 @@ fun HistoryResultBar(
 }
 
 @Composable
-fun TopShadow(
+private fun TopShadow(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
@@ -82,7 +82,7 @@ fun TopShadow(
 
 @Preview
 @Composable
-fun HistoryResultBarPreview() {
+private fun HistoryResultBarPreview() {
     MCDONALDSTheme {
         Column {
             HistoryResultBar(

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistorySquareButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistorySquareButton.kt
@@ -1,15 +1,13 @@
 package org.sopt.mcdonalds.presentation.history.component
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -18,7 +16,7 @@ import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
 @Composable
-fun HistoryStoreChangeButton(
+fun HistorySquareButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -27,18 +25,17 @@ fun HistoryStoreChangeButton(
     Button(
         onClick = onClick,
         modifier = modifier
-            .padding(10.dp),
+            .fillMaxWidth()
+            .height(56.dp),
         enabled = enabled,
-        border = BorderStroke(0.5.dp, McDonaldsTheme.colors.blue),
-        colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.white),
-        shape = RoundedCornerShape(8.dp),
-        contentPadding = PaddingValues(0.dp),
+        colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.yellow),
+        shape = RectangleShape,
         interactionSource = NoRippleInteractionSource,
     ) {
         Text(
             text = text,
-            style = McDonaldsTheme.typography.caption10r,
-            color = McDonaldsTheme.colors.blue,
+            style = McDonaldsTheme.typography.body16m,
+            color = McDonaldsTheme.colors.gray800,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
@@ -47,13 +44,12 @@ fun HistoryStoreChangeButton(
 
 @Preview
 @Composable
-fun HistoryStoreChangeButtonPreview(
+fun HistorySquareButtonPreview(
 ){
     MCDONALDSTheme {
-        HistoryStoreChangeButton(
-            text = "매장 변경",
+        HistorySquareButton(
+            text = "제품 수령 장소 선택",
             onClick = {},
-            modifier = Modifier.size(width = 61.dp, height = 29.dp),
             enabled = true,
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistorySquareButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistorySquareButton.kt
@@ -52,7 +52,7 @@ fun HistorySquareButton(
 
 @Preview
 @Composable
-fun HistorySquareButtonPreview() {
+private fun HistorySquareButtonPreview() {
     MCDONALDSTheme {
         HistorySquareButton(
             text = "제품 수령 장소 선택",

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistorySquareButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistorySquareButton.kt
@@ -15,12 +15,20 @@ import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
+/**
+ * 주문내역 페이지 속에서 주문을 위해 사용하는 버튼
+ *
+ * @param text 버튼에 표시할 텍스트입니다.
+ * @param onClick 버튼 클릭 시 발생할 이벤트 함수입니다.
+ * @param modifier 수정자
+ * @param enabled 버튼의 활성화 여부
+ */
 @Composable
 fun HistorySquareButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
+    enabled: Boolean = true
 ) {
     Button(
         onClick = onClick,
@@ -30,27 +38,26 @@ fun HistorySquareButton(
         enabled = enabled,
         colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.yellow),
         shape = RectangleShape,
-        interactionSource = NoRippleInteractionSource,
+        interactionSource = NoRippleInteractionSource
     ) {
         Text(
             text = text,
             style = McDonaldsTheme.typography.body16m,
             color = McDonaldsTheme.colors.gray800,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }
 
 @Preview
 @Composable
-fun HistorySquareButtonPreview(
-){
+fun HistorySquareButtonPreview() {
     MCDONALDSTheme {
         HistorySquareButton(
             text = "제품 수령 장소 선택",
             onClick = {},
-            enabled = true,
+            enabled = true
         )
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreBar.kt
@@ -5,10 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,18 +65,16 @@ fun HistoryStoreBar(
                 onClick = onStoreChangeClick
             )
         }
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(1.dp)
-                .background(color = McDonaldsTheme.colors.gray300)
+        HorizontalDivider(
+            thickness = 1.dp,
+            color = McDonaldsTheme.colors.gray300
         )
     }
 }
 
 @Preview
 @Composable
-fun HistoryStoreBarPreview() {
+private fun HistoryStoreBarPreview() {
     MCDONALDSTheme {
         Column {
             HistoryStoreBar(

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreBar.kt
@@ -1,0 +1,85 @@
+
+package org.sopt.mcdonalds.presentation.history.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import org.sopt.mcdonalds.R
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+
+@Composable
+fun HistoryStoreBar(
+    store: String,
+    onStoreChangeClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column {
+        Row (
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = McDonaldsTheme.colors.white)
+                .padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row (
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_mcdonalds_location),
+                    contentDescription = null,
+                    tint = Color.Unspecified,
+                )
+                Text(
+                    text = store,
+                    style = McDonaldsTheme.typography.body14b,
+                    color = McDonaldsTheme.colors.black,
+                )
+            }
+            HistoryStoreChangeButton(
+                text = stringResource(R.string.history_store_change),
+                onClick = onStoreChangeClick,
+            )
+        }
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = McDonaldsTheme.colors.gray300),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HistoryStoreBarPreview(){
+    MCDONALDSTheme {
+        Column {
+            HistoryStoreBar(
+                store = "양평SK DT",
+                onStoreChangeClick = {},
+                modifier = Modifier,
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreBar.kt
@@ -20,65 +20,70 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
+/**
+ * 주문내역 페이지 속에서 현재 매장을 보여주는 바
+ *
+ * @param store 바에 표시할 매장 이름입니다.
+ * @param onStoreChangeClick 바 속 매장 변경 버튼 클릭 시 발생할 이벤트 함수입니다.
+ * @param modifier 수정자
+ */
 @Composable
 fun HistoryStoreBar(
     store: String,
     onStoreChangeClick: () -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     Column {
-        Row (
+        Row(
             modifier = modifier
                 .fillMaxWidth()
                 .background(color = McDonaldsTheme.colors.white)
                 .padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Row (
+            Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_mcdonalds_location),
                     contentDescription = null,
-                    tint = Color.Unspecified,
+                    tint = Color.Unspecified
                 )
                 Text(
                     text = store,
                     style = McDonaldsTheme.typography.body14b,
-                    color = McDonaldsTheme.colors.black,
+                    color = McDonaldsTheme.colors.black
                 )
             }
             HistoryStoreChangeButton(
                 text = stringResource(R.string.history_store_change),
-                onClick = onStoreChangeClick,
+                onClick = onStoreChangeClick
             )
         }
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(1.dp)
-                .background(color = McDonaldsTheme.colors.gray300),
+                .background(color = McDonaldsTheme.colors.gray300)
         )
     }
 }
 
 @Preview
 @Composable
-fun HistoryStoreBarPreview(){
+fun HistoryStoreBarPreview() {
     MCDONALDSTheme {
         Column {
             HistoryStoreBar(
                 store = "양평SK DT",
                 onStoreChangeClick = {},
-                modifier = Modifier,
+                modifier = Modifier
             )
         }
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
@@ -1,36 +1,37 @@
 package org.sopt.mcdonalds.presentation.history.component
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
 import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
+/**
+ * 주문내역 페이지 속에서 매장 변경을 위해 사용하는 버튼
+ *
+ * @param text 버튼에 표시할 텍스트입니다.
+ * @param onClick 버튼 클릭 시 발생할 이벤트 함수입니다.
+ * @param modifier 수정자
+ */
 @Composable
 fun HistoryStoreChangeButton(
     text: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     Text(
         modifier = modifier
             .background(
                 color = McDonaldsTheme.colors.white,
-                shape = RoundedCornerShape(8.dp),
+                shape = RoundedCornerShape(8.dp)
             )
             .border(
                 width = 0.5.dp,
@@ -43,19 +44,18 @@ fun HistoryStoreChangeButton(
         style = McDonaldsTheme.typography.caption10r,
         color = McDonaldsTheme.colors.blue,
         maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
+        overflow = TextOverflow.Ellipsis
     )
 }
 
 @Preview
 @Composable
-fun HistoryStoreChangeButtonPreview(
-){
+fun HistoryStoreChangeButtonPreview() {
     MCDONALDSTheme {
         HistoryStoreChangeButton(
             text = "매장 변경",
             onClick = {},
-            modifier = Modifier,
+            modifier = Modifier
         )
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
@@ -1,6 +1,8 @@
 package org.sopt.mcdonalds.presentation.history.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -14,6 +16,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
+import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
@@ -22,27 +25,26 @@ fun HistoryStoreChangeButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
 ) {
-    Button(
-        onClick = onClick,
+    Text(
         modifier = modifier
-            .padding(10.dp),
-        enabled = enabled,
-        border = BorderStroke(0.5.dp, McDonaldsTheme.colors.blue),
-        colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.white),
-        shape = RoundedCornerShape(8.dp),
-        contentPadding = PaddingValues(0.dp),
-        interactionSource = NoRippleInteractionSource,
-    ) {
-        Text(
-            text = text,
-            style = McDonaldsTheme.typography.caption10r,
-            color = McDonaldsTheme.colors.blue,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
+            .background(
+                color = McDonaldsTheme.colors.white,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .border(
+                width = 0.5.dp,
+                color = McDonaldsTheme.colors.blue,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(start = 10.dp, end = 10.dp, top = 5.dp, bottom = 5.dp)
+            .noRippleClickable(onClick),
+        text = text,
+        style = McDonaldsTheme.typography.caption10r,
+        color = McDonaldsTheme.colors.blue,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
 }
 
 @Preview
@@ -53,8 +55,7 @@ fun HistoryStoreChangeButtonPreview(
         HistoryStoreChangeButton(
             text = "매장 변경",
             onClick = {},
-            modifier = Modifier.size(width = 61.dp, height = 29.dp),
-            enabled = true,
+            modifier = Modifier,
         )
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
@@ -1,0 +1,59 @@
+package org.sopt.mcdonalds.presentation.history.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+
+@Composable
+fun HistoryStoreChangeButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier,
+    enabled: Boolean = true,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        border = BorderStroke(0.5.dp, McDonaldsTheme.colors.blue),
+        colors = ButtonDefaults.buttonColors(McDonaldsTheme.colors.white),
+        shape = RoundedCornerShape(8.dp),
+        contentPadding = PaddingValues(0.dp),
+        interactionSource = NoRippleInteractionSource,
+    ) {
+        Text(
+            text = text,
+            style = McDonaldsTheme.typography.caption10r,
+            color = McDonaldsTheme.colors.blue,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HistoryStoreChangeButtonPreview(
+){
+    MCDONALDSTheme {
+        HistoryStoreChangeButton(
+            text = "매장 변경",
+            onClick = {},
+            modifier = Modifier.size(width = 61.dp, height = 29.dp),
+            enabled = true,
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
@@ -50,7 +50,7 @@ fun HistoryStoreChangeButton(
 
 @Preview
 @Composable
-fun HistoryStoreChangeButtonPreview() {
+private fun HistoryStoreChangeButtonPreview() {
     MCDONALDSTheme {
         HistoryStoreChangeButton(
             text = "매장 변경",

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryStoreChangeButton.kt
@@ -2,7 +2,6 @@ package org.sopt.mcdonalds.presentation.history.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryTimeBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryTimeBar.kt
@@ -1,0 +1,74 @@
+package org.sopt.mcdonalds.presentation.history.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import org.sopt.mcdonalds.R
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+
+@Composable
+fun HistoryTimeBar(
+    endTime: LocalDateTime,
+    modifier: Modifier = Modifier,
+) {
+    val formatter = DateTimeFormatter.ofPattern("HH:mm")
+    Column {
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = McDonaldsTheme.colors.gray200),
+        )
+        Row (
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = McDonaldsTheme.colors.gray100)
+                .padding(start = 24.dp, end = 24.dp, top = 7.dp, bottom = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(15.dp),
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_warning_20),
+                contentDescription = null,
+                tint = Color. Unspecified,
+            )
+            Text(
+                text = stringResource(R.string.history_time_notice, endTime.format(formatter)),
+                style = McDonaldsTheme.typography.body14r,
+                color = McDonaldsTheme.colors.black,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun HistoryTimeBarPreview(){
+    MCDONALDSTheme {
+        Column {
+            HistoryTimeBar(
+                endTime = LocalDateTime.now(),
+                modifier = Modifier,
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryTimeBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryTimeBar.kt
@@ -25,10 +25,16 @@ import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 
+/**
+ * 주문내역 페이지 속에서 마감 시간을 보여주는 바
+ *
+ * @param endTime 바에 표시할 매장 마감 시간입니다.
+ * @param modifier 수정자
+ */
 @Composable
 fun HistoryTimeBar(
     endTime: LocalDateTime,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     val formatter = DateTimeFormatter.ofPattern("HH:mm")
     Column {
@@ -36,25 +42,25 @@ fun HistoryTimeBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(1.dp)
-                .background(color = McDonaldsTheme.colors.gray200),
+                .background(color = McDonaldsTheme.colors.gray200)
         )
-        Row (
+        Row(
             modifier = modifier
                 .fillMaxWidth()
                 .background(color = McDonaldsTheme.colors.gray100)
                 .padding(start = 24.dp, end = 24.dp, top = 7.dp, bottom = 7.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(15.dp),
+            horizontalArrangement = Arrangement.spacedBy(15.dp)
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_warning_20),
                 contentDescription = null,
-                tint = Color. Unspecified,
+                tint = Color.Unspecified
             )
             Text(
                 text = stringResource(R.string.history_time_notice, endTime.format(formatter)),
                 style = McDonaldsTheme.typography.body14r,
-                color = McDonaldsTheme.colors.black,
+                color = McDonaldsTheme.colors.black
             )
         }
     }
@@ -62,12 +68,12 @@ fun HistoryTimeBar(
 
 @Preview
 @Composable
-fun HistoryTimeBarPreview(){
+fun HistoryTimeBarPreview() {
     MCDONALDSTheme {
         Column {
             HistoryTimeBar(
                 endTime = LocalDateTime.now(),
-                modifier = Modifier,
+                modifier = Modifier
             )
         }
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryTimeBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryTimeBar.kt
@@ -68,7 +68,7 @@ fun HistoryTimeBar(
 
 @Preview
 @Composable
-fun HistoryTimeBarPreview() {
+private fun HistoryTimeBarPreview() {
     MCDONALDSTheme {
         Column {
             HistoryTimeBar(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">MCDONALDS</string>
+    <string name="history_time_notice">매장 운영시간이 곧 종료되오니 %1$s 전에 픽업 완료해주세요.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">MCDONALDS</string>
     <string name="history_time_notice">매장 운영시간이 곧 종료되오니 %1$s 전에 픽업 완료해주세요.</string>
+    <string name="history_store_change">매장 변경</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed  #10

## Work Description ✏️
- 주문내역 페이지 개별 컴포넌트 구현했습니다.
- presentation/history/component 폴더에서 구현했습니다.

## Screenshot 📸
|HistoryMenuAddButton|HistoryStoreChangeButton|HistoryResultBar|
|------|---|---|
|![image](https://github.com/user-attachments/assets/89f73482-c77f-4f23-8266-f4547761bef3)|![image](https://github.com/user-attachments/assets/d1181097-b745-41ce-820d-4a07395c0d4d)|![image](https://github.com/user-attachments/assets/7c51ec49-5538-49b7-9795-8094941eedd1)|
|HistorySquareButton|HistoryStoreBar|HistoryTimeBar|
|![image](https://github.com/user-attachments/assets/3b4bcd53-d902-47a9-8f41-4b3ad461f325)|![image](https://github.com/user-attachments/assets/76ad4337-3ce3-4a06-87a2-18a0384eebb6)|![image](https://github.com/user-attachments/assets/c3e5924d-4fe1-4042-ab26-8f59881e670f)|

## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢