### PR TITLE
[UI/#18] 주문내역 페이지 리스트 컴포넌트 구현

### DIFF
--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryCartItem.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryCartItem.kt
@@ -1,0 +1,201 @@
+package org.sopt.mcdonalds.presentation.history.component
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import java.text.DecimalFormat
+import org.sopt.mcdonalds.R
+import org.sopt.mcdonalds.core.common.util.noRippleClickable
+import org.sopt.mcdonalds.core.designsystem.component.BorderedNumberIncrementer
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+
+@Composable
+fun HistoryCartItem(
+    price: Int,
+    count: Int,
+    isSet: Boolean,
+    imageUrl: String,
+    menuName: String,
+    onIncrementClick: () -> Unit,
+    onDecrementClick: () -> Unit,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    Column(
+        modifier = modifier
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(17.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(19.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Text(
+                        text = if (isSet) "$menuName - 세트" else menuName,
+                        style = McDonaldsTheme.typography.body14b,
+                        color = McDonaldsTheme.colors.black
+                    )
+                    Column {
+                        Text(
+                            text = menuName,
+                            style = McDonaldsTheme.typography.body14r,
+                            color = McDonaldsTheme.colors.gray600
+                        )
+                        if (isSet) {
+                            Text(
+                                text = stringResource(R.string.history_fries_default_option),
+                                style = McDonaldsTheme.typography.body14r,
+                                color = McDonaldsTheme.colors.gray600
+                            )
+                            Text(
+                                text = stringResource(R.string.history_drink_default_option),
+                                style = McDonaldsTheme.typography.body14r,
+                                color = McDonaldsTheme.colors.gray600
+                            )
+                            Text(
+                                text = stringResource(R.string.history_ingredient_default_option),
+                                style = McDonaldsTheme.typography.body14r,
+                                color = McDonaldsTheme.colors.gray600
+                            )
+                        }
+                    }
+                }
+                AsyncImage(
+                    modifier = Modifier
+                        .sizeIn(
+                            maxWidth = 100.dp,
+                            maxHeight = 100.dp
+                        ),
+                    model = ImageRequest
+                        .Builder(context = context)
+                        .data(imageUrl)
+                        .build(),
+                    contentDescription = null
+                )
+            }
+            Text(
+                text = "₩" + DecimalFormat("#,###").format(price),
+                style = McDonaldsTheme.typography.body14r,
+                color = McDonaldsTheme.colors.black
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            BorderedNumberIncrementer(
+                count = count,
+                onIncrementClick = onIncrementClick,
+                onDecrementClick = onDecrementClick,
+                modifier = Modifier.width(88.dp),
+                textStyle = McDonaldsTheme.typography.body16sb,
+                paddingValues = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(15.dp)
+            ) {
+                HistoryCircleButton(
+                    icon = R.drawable.ic_edit_28,
+                    onClick = onEditClick
+                )
+                HistoryCircleButton(
+                    icon = R.drawable.ic_delete_28,
+                    onClick = onDeleteClick
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryCircleButton(
+    @DrawableRes icon: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(width = 42.dp, height = 42.dp)
+            .background(
+                color = Color.Transparent,
+                shape = RoundedCornerShape(percent = 100)
+            )
+            .border(
+                width = 1.dp,
+                color = McDonaldsTheme.colors.gray200,
+                shape = RoundedCornerShape(percent = 100)
+            )
+            .noRippleClickable(onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(icon),
+            contentDescription = null,
+            tint = McDonaldsTheme.colors.black
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HistoryCartItemPreview() {
+    var num1 by remember { mutableStateOf(0) }
+
+    MCDONALDSTheme {
+        HistoryCartItem(
+            price = 11500,
+            count = num1,
+            isSet = true,
+            imageUrl = "",
+            menuName = "더블 1955® 버거",
+            onIncrementClick = { num1++ },
+            onDecrementClick = { num1-- },
+            onEditClick = {},
+            onDeleteClick = {}
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryRecentBurgerItem.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryRecentBurgerItem.kt
@@ -1,0 +1,94 @@
+package org.sopt.mcdonalds.presentation.history.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import java.text.DecimalFormat
+import org.sopt.mcdonalds.core.common.util.noRippleClickable
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+
+@Composable
+fun HistoryRecentBurgerItem(
+    price: Int,
+    imageUrl: String,
+    menuName: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 21.dp, vertical = 18.dp)
+                .noRippleClickable(onClick),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .sizeIn(
+                        maxWidth = 69.dp,
+                        maxHeight = 54.dp
+                    ),
+                model = ImageRequest
+                    .Builder(context = context)
+                    .data(imageUrl)
+                    .build(),
+                contentDescription = null
+            )
+            Column(
+                modifier = modifier
+                    .padding(horizontal = 0.dp, vertical = 4.dp),
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = menuName,
+                    style = McDonaldsTheme.typography.body14b,
+                    color = McDonaldsTheme.colors.gray800
+                )
+                Text(
+                    text = "₩" + DecimalFormat("#,###").format(price) + "~",
+                    style = McDonaldsTheme.typography.body14r,
+                    color = McDonaldsTheme.colors.gray800
+                )
+            }
+        }
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth(),
+            thickness = 0.5.dp,
+            color = McDonaldsTheme.colors.gray200
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HistoryRecentBurgerItemPreview() {
+    MCDONALDSTheme {
+        HistoryRecentBurgerItem(
+            price = 8300,
+            imageUrl = "",
+            menuName = "더블 1955® 버거",
+            onClick = {}
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryRecentBurgerItem.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryRecentBurgerItem.kt
@@ -65,7 +65,7 @@ fun HistoryRecentBurgerItem(
                     color = McDonaldsTheme.colors.gray800
                 )
                 Text(
-                    text = "₩" + DecimalFormat("#,###").format(price) + "~",
+                    text = "₩" + DecimalFormat("#,###").format(price) + " ~",
                     style = McDonaldsTheme.typography.body14r,
                     color = McDonaldsTheme.colors.gray800
                 )

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/component/HistoryResultBar.kt
@@ -24,13 +24,13 @@ import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
  * 주문내역 페이지 속에서 최종 금액 표시를 위한 바
  *
  * @param text 바에 표시할 텍스트입니다.
- * @param amount 바에 표시할 최종 금액입니다.
+ * @param price 바에 표시할 최종 금액입니다.
  * @param modifier 수정자
  */
 @Composable
 fun HistoryResultBar(
     text: String,
-    amount: Int,
+    price: Int,
     modifier: Modifier = Modifier
 ) {
     TopShadow(
@@ -50,7 +50,7 @@ fun HistoryResultBar(
                 color = McDonaldsTheme.colors.black
             )
             Text(
-                text = "₩" + DecimalFormat("#,###").format(amount),
+                text = "₩" + DecimalFormat("#,###").format(price),
                 style = McDonaldsTheme.typography.body18m,
                 color = McDonaldsTheme.colors.black
             )
@@ -87,7 +87,7 @@ private fun HistoryResultBarPreview() {
         Column {
             HistoryResultBar(
                 text = "주문 금액",
-                amount = 11500,
+                price = 11500,
                 modifier = Modifier
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
     <string name="app_name">MCDONALDS</string>
     <string name="history_time_notice">매장 운영시간이 곧 종료되오니 %1$s 전에 픽업 완료해주세요.</string>
     <string name="history_store_change">매장 변경</string>
+    <string name="history_fries_default_option">후렌치 후라이 - 미디엄</string>
+    <string name="history_drink_default_option">스프라이트 - 미디엄</string>
+    <string name="history_ingredient_default_option">선택 안함</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #18 

## Work Description ✏️
- 주문내역 페이지 리스트 컴포넌트 구현

## Screenshot 📸
- HistoryCartItem
![image](https://github.com/user-attachments/assets/20c632dc-543b-4dae-9fe5-c09140e6efc1)

- HistoryRecentBurgerItem
![image](https://github.com/user-attachments/assets/425d0265-a0b3-491e-a142-eca85edb9508)


## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢
- 둘 다 햄버거 사진이 들어가는데, AsyncImage라서 프리뷰에서는 표출하기 힘들어서, 스크린샷에는 안보이는 점을... 양해 부탁드립니닷