### PR TITLE
[FEAT/#26] 메뉴리스트 화면 로직 구현

### DIFF
--- a/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainActivity.kt
@@ -4,8 +4,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import org.sopt.mcdonalds.presentation.menu.navigation.menuListGraph
+import org.sopt.mcdonalds.presentation.menu.navigation.navigateToMenuList
 import org.sopt.mcdonalds.presentation.store.navigation.Store
 import org.sopt.mcdonalds.presentation.store.navigation.storeGraph
 
@@ -39,7 +41,13 @@ private fun MainNavHost(
         startDestination = Store,
     ) {
         storeGraph(
-            onNavigateToMenuList = { /* TODO */ },
+            onNavigateToMenuList = navController::navigateToMenuList,
+            modifier = modifier,
+        )
+
+        menuListGraph(
+            onNavigateToUp = navController::navigateUp,
+            onNavigateToOrder = { /* TODO */ },
             modifier = modifier,
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListScreen.kt
@@ -5,31 +5,46 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.persistentListOf
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toPersistentList
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 import org.sopt.mcdonalds.presentation.menu.component.MenuListContent
 import org.sopt.mcdonalds.presentation.menu.component.MenuListFilterGroup
 import org.sopt.mcdonalds.presentation.menu.component.MenuListTopBar
+import org.sopt.mcdonalds.presentation.menu.state.MenuListContract.MenuListState
 import org.sopt.mcdonalds.presentation.menu.type.MenuType
 
 @Composable
 fun MenuListRoute(
-    modifier: Modifier = Modifier
+    onNavigateToOrder: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MenuListViewModel = hiltViewModel()
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
     MenuListScreen(
+        uiState = uiState,
+        onMenuClick = onNavigateToOrder,
         modifier = modifier
     )
 }
 
 @Composable
 private fun MenuListScreen(
+    uiState: MenuListState,
+    onMenuClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val selectedMenuType by remember { mutableStateOf(MenuType.NEW) }
+
     Column(
         modifier = modifier
     ) {
@@ -40,15 +55,17 @@ private fun MenuListScreen(
         Spacer(modifier = Modifier.height(16.dp))
 
         MenuListFilterGroup(
-            selectedMenuType = MenuType.NEW,
+            selectedMenuType = selectedMenuType,
             menuTypes = MenuType.entries.toPersistentList(),
-            onMenuTypeSelect = { /* TODO */ }
+            onMenuTypeSelect = {
+            }
         )
 
         Spacer(modifier = Modifier.height(16.dp))
 
         MenuListContent(
-            menus = persistentListOf(),
+            menus = uiState.menuList,
+            onMenuClick = onMenuClick,
             modifier = modifier
         )
     }
@@ -59,6 +76,8 @@ private fun MenuListScreen(
 private fun MenuListScreenPreview() {
     MCDONALDSTheme {
         MenuListScreen(
+            uiState = MenuListState(),
+            onMenuClick = {},
             modifier = Modifier.background(McDonaldsTheme.colors.white)
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,6 +25,7 @@ import org.sopt.mcdonalds.presentation.menu.type.MenuType
 
 @Composable
 fun MenuListRoute(
+    onBackClick: () -> Unit,
     onNavigateToOrder: (Long) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MenuListViewModel = hiltViewModel()
@@ -32,6 +34,7 @@ fun MenuListRoute(
 
     MenuListScreen(
         uiState = uiState,
+        onBackClick = onBackClick,
         onMenuClick = onNavigateToOrder,
         modifier = modifier
     )
@@ -40,24 +43,26 @@ fun MenuListRoute(
 @Composable
 private fun MenuListScreen(
     uiState: MenuListState,
+    onBackClick: () -> Unit,
     onMenuClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val selectedMenuType by remember { mutableStateOf(MenuType.NEW) }
+    var menuType by remember { mutableStateOf(MenuType.NEW) }
 
     Column(
         modifier = modifier
     ) {
         MenuListTopBar(
-            onBackClick = { /* TODO */ }
+            onBackClick = onBackClick
         )
 
         Spacer(modifier = Modifier.height(16.dp))
 
         MenuListFilterGroup(
-            selectedMenuType = selectedMenuType,
+            selectedMenuType = menuType,
             menuTypes = MenuType.entries.toPersistentList(),
             onMenuTypeSelect = {
+                menuType = it
             }
         )
 
@@ -77,6 +82,7 @@ private fun MenuListScreenPreview() {
     MCDONALDSTheme {
         MenuListScreen(
             uiState = MenuListState(),
+            onBackClick = {},
             onMenuClick = {},
             modifier = Modifier.background(McDonaldsTheme.colors.white)
         )

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListViewModel.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListViewModel.kt
@@ -1,0 +1,29 @@
+package org.sopt.mcdonalds.presentation.menu
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.sopt.mcdonalds.presentation.menu.model.Menu
+import org.sopt.mcdonalds.presentation.menu.state.MenuListContract.MenuListState
+
+@HiltViewModel
+class MenuListViewModel @Inject constructor(
+    // TODO: API Connection
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(MenuListState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        // TODO: API call
+    }
+
+    private fun updateMenuList(menuList: List<Menu>) {
+        _uiState.update {
+            it.copy(menuList = menuList.toImmutableList())
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListContent.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
+import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 import org.sopt.mcdonalds.presentation.menu.model.Menu
@@ -24,6 +25,7 @@ import org.sopt.mcdonalds.presentation.menu.model.Menu
 @Composable
 fun MenuListContent(
     menus: ImmutableList<Menu>,
+    onMenuClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -36,7 +38,10 @@ fun MenuListContent(
             MenuListItem(
                 imageUrl = menu.imageUrl,
                 menuName = menu.name,
-                menuPrice = menu.price
+                menuPrice = menu.price,
+                modifier = Modifier.noRippleClickable {
+                    onMenuClick(menu.menuId)
+                }
             )
         }
     }
@@ -108,6 +113,7 @@ private fun MenuListContentPreview() {
                     imageUrl = "https://example.com/mcchicken.jpg"
                 )
             ).toPersistentList(),
+            onMenuClick = {},
             modifier = Modifier.background(McDonaldsTheme.colors.white)
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListFilterGroup.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListFilterGroup.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
+import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.component.ChipButton
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
@@ -21,8 +22,8 @@ import org.sopt.mcdonalds.presentation.menu.type.MenuType
 fun MenuListFilterGroup(
     selectedMenuType: MenuType,
     menuTypes: ImmutableList<MenuType>,
-    onMenuTypeSelect: () -> Unit,
-    modifier: Modifier = Modifier
+    onMenuTypeSelect: (MenuType) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyRow(
         modifier = modifier,
@@ -39,7 +40,11 @@ fun MenuListFilterGroup(
             ChipButton(
                 isSelected = selectedMenuType == menuType,
                 title = menuType.title,
-                modifier = Modifier.padding(start = padStart, end = padEnd),
+                modifier = Modifier
+                    .padding(start = padStart, end = padEnd)
+                    .noRippleClickable {
+                        onMenuTypeSelect(menuType)
+                    },
                 textStyle = McDonaldsTheme.typography.body12r.copy(
                     color = McDonaldsTheme.colors.black
                 ),

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/navigation/MenuListNavigation.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/navigation/MenuListNavigation.kt
@@ -1,0 +1,28 @@
+package org.sopt.mcdonalds.presentation.menu.navigation
+
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import kotlinx.serialization.Serializable
+import org.sopt.mcdonalds.core.common.navigation.Route
+import org.sopt.mcdonalds.presentation.menu.MenuListRoute
+
+fun NavController.navigateToMenuList(navOptions: NavOptions? = null) =
+    navigate(MenuList, navOptions)
+
+fun NavGraphBuilder.menuListGraph(
+    onNavigateToOrder: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    composable<MenuList> {
+        MenuListRoute(
+            onNavigateToOrder = onNavigateToOrder,
+            modifier = modifier
+        )
+    }
+}
+
+@Serializable
+data object MenuList : Route

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/navigation/MenuListNavigation.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/navigation/MenuListNavigation.kt
@@ -13,11 +13,13 @@ fun NavController.navigateToMenuList(navOptions: NavOptions? = null) =
     navigate(MenuList, navOptions)
 
 fun NavGraphBuilder.menuListGraph(
+    onNavigateToUp: () -> Unit,
     onNavigateToOrder: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     composable<MenuList> {
         MenuListRoute(
+            onBackClick = onNavigateToUp,
             onNavigateToOrder = onNavigateToOrder,
             modifier = modifier
         )

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/state/MenuListContract.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/state/MenuListContract.kt
@@ -1,0 +1,13 @@
+package org.sopt.mcdonalds.presentation.menu.state
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import org.sopt.mcdonalds.presentation.menu.model.Menu
+
+class MenuListContract {
+    @Immutable
+    data class MenuListState(
+        val menuList: ImmutableList<Menu> = persistentListOf()
+    )
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #26

## Work Description ✏️
- 이전 화면과 네비게이션 연결

## Screenshot 📸

https://github.com/user-attachments/assets/05297cd1-bc72-475e-9609-e06ea67961ca

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
생각보다 크게 작업한 건 없고 앞 뒤 화면 네비게이션 연결하고, 필터 버튼이 변경되게끔 로직만 추가했습니다.
그 외에 API 연결을 위해 뷰모델까지만 생성해뒀습니다!