### PR TITLE
[FEAT/#34] 메뉴리스트 화면 API 연결

### DIFF
--- a/app/src/main/java/org/sopt/mcdonalds/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/core/network/AuthInterceptor.kt
@@ -1,41 +1,25 @@
 package org.sopt.mcdonalds.core.network
 
-import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
-import okhttp3.Request
 import okhttp3.Response
 import org.sopt.mcdonalds.core.local.TokenDataStore
-import timber.log.Timber
+import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    private val tokenDataStore: TokenDataStore
+    private val tokenDataStore: TokenDataStore,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
-        val authRequest = runBlocking {
-            val token = tokenDataStore.getAccessToken()
+        val accessToken = runBlocking { tokenDataStore.getAccessToken() }
 
-            Timber.tag("AuthInterceptor").d("ACCESS TOKEN: $token")
-
-            if (token?.isNotBlank() == true) {
-                originalRequest.newBuilder().newAuthBuilder().build()
-            } else {
-                originalRequest
+        val authenticatedRequest = originalRequest.newBuilder().apply {
+            if (!accessToken.isNullOrBlank()) {
+                header("userId", accessToken)
             }
-        }
+        }.build()
 
-        val response = chain.proceed(authRequest)
-
-        return response
-    }
-
-    private suspend fun Request.Builder.newAuthBuilder() =
-        this.addHeader(AUTHORIZATION, "$BEARER ${tokenDataStore.getAccessToken()}")
-
-    companion object {
-        private const val BEARER = "Bearer"
-        private const val AUTHORIZATION = "Authorization"
+        return chain.proceed(authenticatedRequest)
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/core/network/BaseResponse.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/core/network/BaseResponse.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class BaseResponse<T>(
-    @SerialName("status")
-    val status: Int,
+    @SerialName("code")
+    val code: Int,
     @SerialName("message")
     val message: String,
     @SerialName("data")

--- a/app/src/main/java/org/sopt/mcdonalds/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/core/network/di/NetworkModule.kt
@@ -5,7 +5,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
@@ -20,6 +19,7 @@ import org.sopt.mcdonalds.core.network.isJsonObject
 import retrofit2.Converter
 import retrofit2.Retrofit
 import timber.log.Timber
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -63,43 +63,26 @@ object NetworkModule {
     @JWT
     @Provides
     @Singleton
-    fun provideJWTHttpLoggingInterceptor(authInterceptor: AuthInterceptor): Interceptor =
-        authInterceptor
+    fun provideJwtInterceptor(
+        authInterceptor: AuthInterceptor,
+    ): Interceptor = authInterceptor
 
+    @JWT
     @Provides
     @Singleton
     fun provideOkHttpClient(
-        loggingInterceptor: Interceptor
+        loggingInterceptor: Interceptor,
+        @JWT headerInterceptor: Interceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
+        .addInterceptor(headerInterceptor)
         .build()
 
-    @JWT
     @Provides
     @Singleton
-    fun provideJWTOkHttpClient(
-        loggingInterceptor: Interceptor,
-        authInterceptor: AuthInterceptor
-    ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(loggingInterceptor)
-        .addInterceptor(authInterceptor)
-        .build()
-
-    @Provides
     fun provideRetrofit(
-        client: OkHttpClient,
-        factory: Converter.Factory
-    ): Retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .client(client)
-        .addConverterFactory(factory)
-        .build()
-
-    @JWT
-    @Provides
-    fun provideJWTRetrofit(
         @JWT client: OkHttpClient,
-        factory: Converter.Factory
+        factory: Converter.Factory,
     ): Retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
         .client(client)

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/datasource/MenuDataSource.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/datasource/MenuDataSource.kt
@@ -1,0 +1,12 @@
+package org.sopt.mcdonalds.data.menu.datasource
+
+import org.sopt.mcdonalds.data.menu.service.MenuService
+import javax.inject.Inject
+
+class MenuDataSource @Inject constructor(
+    private val menuService: MenuService
+) {
+    suspend fun getMenus() = menuService.getMenus().data
+
+    suspend fun getMenuDetail(id: Long) = menuService.getMenuDetail(id).data
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/di/RepositoryModule.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/di/RepositoryModule.kt
@@ -1,0 +1,19 @@
+package org.sopt.mcdonalds.data.menu.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.sopt.mcdonalds.data.menu.repository.MenuRepositoryImpl
+import org.sopt.mcdonalds.domain.menu.repository.MenuRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindMenuRepository(
+        menuRepositoryImpl: MenuRepositoryImpl,
+    ): MenuRepository
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/di/ServiceModule.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/di/ServiceModule.kt
@@ -1,0 +1,19 @@
+package org.sopt.mcdonalds.data.menu.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.sopt.mcdonalds.data.menu.service.MenuService
+import retrofit2.Retrofit
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+    @Provides
+    @Singleton
+    fun provideMenuService(retrofit: Retrofit): MenuService =
+        retrofit.create()
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/dto/MenuDetailResponse.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/dto/MenuDetailResponse.kt
@@ -1,0 +1,20 @@
+package org.sopt.mcdonalds.data.menu.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MenuDetailResponse(
+    @SerialName("menuId")
+    val id: Long,
+    @SerialName("menuName")
+    val name: String,
+    @SerialName("singleImg")
+    val singleImg: String,
+    @SerialName("singlePrice")
+    val singlePrice: String,
+    @SerialName("setImg")
+    val setImg: String,
+    @SerialName("setPrice")
+    val setPrice: String
+)

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/dto/MenuListResponse.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/dto/MenuListResponse.kt
@@ -1,0 +1,22 @@
+package org.sopt.mcdonalds.data.menu.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MenuListResponse(
+    @SerialName("menuList")
+    val menus: List<MenuDto>
+)
+
+@Serializable
+data class MenuDto(
+    @SerialName("menuId")
+    val id: Long,
+    @SerialName("menuName")
+    val name: String,
+    @SerialName("menuImg")
+    val img: String,
+    @SerialName("menuPrice")
+    val price: String
+)

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/mapper/MenuMapper.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/mapper/MenuMapper.kt
@@ -1,0 +1,24 @@
+package org.sopt.mcdonalds.data.menu.mapper
+
+import org.sopt.mcdonalds.data.menu.dto.MenuDetailResponse
+import org.sopt.mcdonalds.data.menu.dto.MenuListResponse
+import org.sopt.mcdonalds.domain.menu.model.Menu
+import org.sopt.mcdonalds.domain.menu.model.MenuDetail
+
+fun MenuListResponse.toDomain() = this.menus.map {
+    Menu(
+        id = it.id,
+        name = it.name,
+        imageUrl = it.img,
+        price = it.price,
+    )
+}
+
+fun MenuDetailResponse.toDomain() = MenuDetail(
+    id = this.id,
+    name = this.name,
+    singleImg = this.singleImg,
+    singlePrice = this.singlePrice,
+    setImg = this.setImg,
+    setPrice = this.setPrice,
+)

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/repository/MenuRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/repository/MenuRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package org.sopt.mcdonalds.data.menu.repository
+
+import org.sopt.mcdonalds.data.menu.datasource.MenuDataSource
+import org.sopt.mcdonalds.data.menu.mapper.toDomain
+import org.sopt.mcdonalds.domain.menu.model.Menu
+import org.sopt.mcdonalds.domain.menu.model.MenuDetail
+import org.sopt.mcdonalds.domain.menu.repository.MenuRepository
+import javax.inject.Inject
+
+class MenuRepositoryImpl @Inject constructor(
+    private val menuDataSource: MenuDataSource,
+) : MenuRepository {
+    override suspend fun getMenus(): Result<List<Menu>> = runCatching {
+        menuDataSource.getMenus()
+    }.mapCatching {
+        it.toDomain()
+    }
+
+    override suspend fun getMenuDetail(menuId: Long): Result<MenuDetail> = runCatching {
+        menuDataSource.getMenuDetail(menuId)
+    }.mapCatching {
+        it.toDomain()
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/menu/service/MenuService.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/menu/service/MenuService.kt
@@ -1,0 +1,17 @@
+package org.sopt.mcdonalds.data.menu.service
+
+import org.sopt.mcdonalds.core.network.BaseResponse
+import org.sopt.mcdonalds.data.menu.dto.MenuListResponse
+import org.sopt.mcdonalds.data.menu.dto.MenuDetailResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface MenuService {
+    @GET("menu")
+    suspend fun getMenus(): BaseResponse<MenuListResponse>
+
+    @GET("menu/{menuId}")
+    suspend fun getMenuDetail(
+        @Path("menuId") menuId: Long
+    ): BaseResponse<MenuDetailResponse>
+}

--- a/app/src/main/java/org/sopt/mcdonalds/domain/menu/model/Menu.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/menu/model/Menu.kt
@@ -1,0 +1,8 @@
+package org.sopt.mcdonalds.domain.menu.model
+
+data class Menu(
+    val id: Long,
+    val name: String,
+    val imageUrl: String,
+    val price: String,
+)

--- a/app/src/main/java/org/sopt/mcdonalds/domain/menu/model/MenuDetail.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/menu/model/MenuDetail.kt
@@ -1,0 +1,10 @@
+package org.sopt.mcdonalds.domain.menu.model
+
+data class MenuDetail(
+    val id: Long,
+    val name: String,
+    val singleImg: String,
+    val singlePrice: String,
+    val setImg: String,
+    val setPrice: String,
+)

--- a/app/src/main/java/org/sopt/mcdonalds/domain/menu/repository/MenuRepository.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/menu/repository/MenuRepository.kt
@@ -1,0 +1,10 @@
+package org.sopt.mcdonalds.domain.menu.repository
+
+import org.sopt.mcdonalds.domain.menu.model.Menu
+import org.sopt.mcdonalds.domain.menu.model.MenuDetail
+
+interface MenuRepository {
+    suspend fun getMenus(): Result<List<Menu>>
+
+    suspend fun getMenuDetail(menuId: Long): Result<MenuDetail>
+}

--- a/app/src/main/java/org/sopt/mcdonalds/domain/menu/usecase/GetMenuDetailUseCase.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/menu/usecase/GetMenuDetailUseCase.kt
@@ -1,0 +1,10 @@
+package org.sopt.mcdonalds.domain.menu.usecase
+
+import org.sopt.mcdonalds.domain.menu.repository.MenuRepository
+import javax.inject.Inject
+
+class GetMenuDetailUseCase @Inject constructor(
+    private val menuRepository: MenuRepository,
+) {
+    suspend operator fun invoke(menuId: Long) = menuRepository.getMenuDetail(menuId)
+}

--- a/app/src/main/java/org/sopt/mcdonalds/domain/menu/usecase/GetMenusUseCase.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/menu/usecase/GetMenusUseCase.kt
@@ -1,0 +1,10 @@
+package org.sopt.mcdonalds.domain.menu.usecase
+
+import org.sopt.mcdonalds.domain.menu.repository.MenuRepository
+import javax.inject.Inject
+
+class GetMenusUseCase @Inject constructor(
+    private val menuRepository: MenuRepository,
+) {
+    suspend operator fun invoke() = menuRepository.getMenus()
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListScreen.kt
@@ -71,7 +71,7 @@ private fun MenuListScreen(
         MenuListContent(
             menus = uiState.menuList,
             onMenuClick = onMenuClick,
-            modifier = modifier
+            modifier = Modifier
         )
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListViewModel.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/MenuListViewModel.kt
@@ -1,29 +1,38 @@
 package org.sopt.mcdonalds.presentation.menu
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
-import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import org.sopt.mcdonalds.presentation.menu.model.Menu
+import kotlinx.coroutines.launch
+import org.sopt.mcdonalds.domain.menu.model.Menu
+import org.sopt.mcdonalds.domain.menu.usecase.GetMenusUseCase
 import org.sopt.mcdonalds.presentation.menu.state.MenuListContract.MenuListState
+import javax.inject.Inject
 
 @HiltViewModel
 class MenuListViewModel @Inject constructor(
-    // TODO: API Connection
+    private val getMenusUseCase: GetMenusUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(MenuListState())
     val uiState = _uiState.asStateFlow()
 
     init {
-        // TODO: API call
+        viewModelScope.launch {
+            getMenusUseCase().onSuccess {
+                updateMenuList(it)
+            }.onFailure {
+                // TODO: API Called Failed
+            }
+        }
     }
 
     private fun updateMenuList(menuList: List<Menu>) {
         _uiState.update {
-            it.copy(menuList = menuList.toImmutableList())
+            it.copy(menuList = menuList.toPersistentList())
         }
     }
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListContent.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.HorizontalDivider
@@ -73,7 +74,7 @@ private fun MenuListItem(
                     .crossfade(true)
                     .build(),
                 contentDescription = null,
-                modifier = modifier
+                modifier = Modifier.width(70.dp)
             )
 
             Column(

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListContent.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/component/MenuListContent.kt
@@ -12,35 +12,37 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
-import org.sopt.mcdonalds.presentation.menu.model.Menu
+import org.sopt.mcdonalds.domain.menu.model.Menu
 
 @Composable
 fun MenuListContent(
     menus: ImmutableList<Menu>,
     onMenuClick: (Long) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     LazyColumn(
         modifier = modifier
     ) {
         itemsIndexed(
             items = menus,
-            key = { _, menu -> menu.menuId }
+            key = { _, menu -> menu.id }
         ) { _, menu ->
             MenuListItem(
                 imageUrl = menu.imageUrl,
                 menuName = menu.name,
                 menuPrice = menu.price,
                 modifier = Modifier.noRippleClickable {
-                    onMenuClick(menu.menuId)
+                    onMenuClick(menu.id)
                 }
             )
         }
@@ -52,8 +54,10 @@ private fun MenuListItem(
     imageUrl: String,
     menuName: String,
     menuPrice: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+
     Column(
         modifier = modifier
     ) {
@@ -63,7 +67,11 @@ private fun MenuListItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
-                model = imageUrl,
+                model = ImageRequest
+                    .Builder(context)
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .build(),
                 contentDescription = null,
                 modifier = modifier
             )
@@ -101,13 +109,13 @@ private fun MenuListContentPreview() {
         MenuListContent(
             menus = listOf(
                 Menu(
-                    menuId = 1,
+                    id = 1,
                     name = "더블 1955® 버거",
                     price = "₩9,500 ~",
                     imageUrl = "https://example.com/bigmac.jpg"
                 ),
                 Menu(
-                    menuId = 2,
+                    id = 2,
                     name = "더블 맥스파이시® 상하이 버거",
                     price = "₩8,900 ~",
                     imageUrl = "https://example.com/mcchicken.jpg"

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/model/Menu.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/model/Menu.kt
@@ -1,8 +1,0 @@
-package org.sopt.mcdonalds.presentation.menu.model
-
-data class Menu(
-    val menuId: Long,
-    val imageUrl: String,
-    val name: String,
-    val price: String
-)

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/menu/state/MenuListContract.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/menu/state/MenuListContract.kt
@@ -3,7 +3,7 @@ package org.sopt.mcdonalds.presentation.menu.state
 import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import org.sopt.mcdonalds.presentation.menu.model.Menu
+import org.sopt.mcdonalds.domain.menu.model.Menu
 
 class MenuListContract {
     @Immutable


### PR DESCRIPTION
## Related issue 🛠
- closed #34

## Work Description ✏️
- 메뉴리스트 화면에서 **전체 메뉴 불러오기 API** 및 이후 화면에서 사용될 **메뉴 상세정보 불르오기 API** 밑작업
- 메뉴리스트 불러오기 API 뷰와 연동

## Screenshot 📸

https://github.com/user-attachments/assets/8d7b89e0-705d-40fa-a115-c36365745d57

메뉴 클릭 시 id 콜백 결과
<img width="562" alt="스크린샷 2025-05-20 오후 3 11 06" src="https://github.com/user-attachments/assets/5f3d79cf-4f15-43df-bf2c-79496f64627f" />

## Uncompleted Tasks 😅

## To Reviewers 📢
~~현재 이미지 url이 잘못 내려와서 세트 이미지이지만, 디비 수정되면 단품 이미지로 알아서 변경될겁니다!~~
수정됐습니다!

<img width="346" alt="스크린샷 2025-05-20 오후 3 29 28" src="https://github.com/user-attachments/assets/4cb40034-677e-4669-81f0-6eba748c8e17" />

