### PR TITLE
[UI/#28] 주문내역 변경 BottomSheet 구현

### DIFF
--- a/app/src/main/java/org/sopt/mcdonalds/presentation/bottomsheet/CartEditBottomSheetScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/bottomsheet/CartEditBottomSheetScreen.kt
@@ -1,0 +1,187 @@
+package org.sopt.mcdonalds.presentation.bottomsheet
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.persistentListOf
+import org.sopt.mcdonalds.R
+import org.sopt.mcdonalds.R.drawable.ic_close_24
+import org.sopt.mcdonalds.R.string.select_store
+import org.sopt.mcdonalds.core.common.util.noRippleClickable
+import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
+import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+import org.sopt.mcdonalds.presentation.history.model.Cart
+import org.sopt.mcdonalds.presentation.order.component.OrderBurgerDetailContainer
+import org.sopt.mcdonalds.presentation.order.component.OrderSideDetailContainer
+import org.sopt.mcdonalds.presentation.order.model.Burger
+import org.sopt.mcdonalds.presentation.order.model.Side
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CartEditBottomSheetRoute(
+    cart: Cart,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    //TODO: uiState 추가
+
+    val sheetState = rememberModalBottomSheetState()
+    CartEditBottomSheetScreen(
+        cart = cart,
+        onDismiss = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CartEditBottomSheetScreen (
+    cart: Cart,
+    onDismiss: () -> Unit,
+    sheetState: SheetState,
+    modifier: Modifier = Modifier
+){
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
+        dragHandle = null
+    ) {
+        Column (
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = McDonaldsTheme.colors.white)
+                .padding(25.dp)
+        ) {
+            Row (
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ){
+                Text(
+                    text = if (cart.isSet) "${cart.menuName} - 세트" else cart.menuName,
+                    style = McDonaldsTheme.typography.body14b,
+                    color = McDonaldsTheme.colors.black
+                )
+                Icon(
+                    imageVector = ImageVector.vectorResource(ic_close_24),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .noRippleClickable(onDismiss),
+                    tint = McDonaldsTheme.colors.black
+                )
+            }
+            Spacer(modifier = Modifier.height(17.dp))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                OrderBurgerDetailContainer(
+                    name = cart.menuName,
+                    imageId = R.drawable.img_burger_single,
+                    ingredientList = persistentListOf()
+                )
+                if(cart.isSet){
+                    OrderSideDetailContainer(
+                        ingredientList = persistentListOf(),
+                        sideList = persistentListOf(
+                            Side(
+                                name = stringResource(R.string.order_side_french_fries),
+                                imageId = R.drawable.img_side_fries
+                            ),
+                            Side(
+                                name = stringResource(R.string.order_side_coleslaw),
+                                imageId = R.drawable.img_side_coleslaw
+                            )
+                        )
+                    )
+                    OrderSideDetailContainer(
+                        ingredientList = persistentListOf(),
+                        sideList = persistentListOf(
+                            Side(
+                                name = stringResource(R.string.order_drink_sprite),
+                                imageId = R.drawable.img_drink_sprite
+                            ),
+                            Side(
+                                name = stringResource(R.string.order_drink_coke),
+                                imageId = R.drawable.img_drink_coke
+                            ),
+                            Side(
+                                name = stringResource(R.string.order_drink_zero_coke),
+                                imageId = R.drawable.img_drink_zero_coke
+                            )
+                        )
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(30.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = McDonaldsTheme.colors.yellow,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .padding(vertical = 12.dp)
+                    .noRippleClickable(onDismiss),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.bottom_sheet_confirm_button),
+                    style = McDonaldsTheme.typography.body14r.copy(
+                        color = McDonaldsTheme.colors.gray800
+                    )
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun CartEditBottomSheetScreenPreview(){
+    MCDONALDSTheme {
+        CartEditBottomSheetScreen(
+            cart = Cart(
+                cartId = 1,
+                amount = 1,
+                price = 11500,
+                menuName = "더블 1955® 버거",
+                imageUrl = "",
+                isSet = true
+            ),
+            onDismiss = {},
+            sheetState = SheetState(
+                skipPartiallyExpanded = true,
+                initialValue = SheetValue.Expanded,
+                confirmValueChange = { true },
+                skipHiddenState = false
+            )
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/bottomsheet/CartEditBottomSheetScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/bottomsheet/CartEditBottomSheetScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,42 +27,39 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.R.drawable.ic_close_24
-import org.sopt.mcdonalds.R.string.select_store
 import org.sopt.mcdonalds.core.common.util.noRippleClickable
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
 import org.sopt.mcdonalds.presentation.history.model.Cart
 import org.sopt.mcdonalds.presentation.order.component.OrderBurgerDetailContainer
 import org.sopt.mcdonalds.presentation.order.component.OrderSideDetailContainer
-import org.sopt.mcdonalds.presentation.order.model.Burger
 import org.sopt.mcdonalds.presentation.order.model.Side
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CartEditBottomSheetScreen (
+fun CartEditBottomSheetScreen(
     cart: Cart,
     onDismiss: () -> Unit,
     sheetState: SheetState,
     modifier: Modifier = Modifier
-){
-
+) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
         dragHandle = null
     ) {
-        Column (
+        Column(
             modifier = modifier
                 .fillMaxWidth()
                 .background(color = McDonaldsTheme.colors.white)
                 .padding(25.dp)
         ) {
-            Row (
+            Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
-            ){
+            ) {
                 Text(
                     text = if (cart.isSet) "${cart.menuName} - 세트" else cart.menuName,
                     style = McDonaldsTheme.typography.body14b,
@@ -88,7 +84,7 @@ fun CartEditBottomSheetScreen (
                     imageId = R.drawable.img_burger_single,
                     ingredientList = persistentListOf()
                 )
-                if(cart.isSet){
+                if (cart.isSet) {
                     OrderSideDetailContainer(
                         ingredientList = persistentListOf(),
                         sideList = persistentListOf(
@@ -147,7 +143,7 @@ fun CartEditBottomSheetScreen (
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
-private fun CartEditBottomSheetScreenPreview(){
+private fun CartEditBottomSheetScreenPreview() {
     MCDONALDSTheme {
         CartEditBottomSheetScreen(
             cart = Cart(

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/bottomsheet/CartEditBottomSheetScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/bottomsheet/CartEditBottomSheetScreen.kt
@@ -40,30 +40,13 @@ import org.sopt.mcdonalds.presentation.order.model.Side
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CartEditBottomSheetRoute(
-    cart: Cart,
-    onDismiss: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    //TODO: uiState 추가
-
-    val sheetState = rememberModalBottomSheetState()
-    CartEditBottomSheetScreen(
-        cart = cart,
-        onDismiss = onDismiss,
-        sheetState = sheetState,
-        modifier = modifier
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun CartEditBottomSheetScreen (
+fun CartEditBottomSheetScreen (
     cart: Cart,
     onDismiss: () -> Unit,
     sheetState: SheetState,
     modifier: Modifier = Modifier
 ){
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/HistoryScreen.kt
@@ -14,7 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,6 +39,7 @@ import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.core.designsystem.component.DefaultTopBar
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+import org.sopt.mcdonalds.presentation.bottomsheet.CartEditBottomSheetScreen
 import org.sopt.mcdonalds.presentation.history.component.HistoryCartItem
 import org.sopt.mcdonalds.presentation.history.component.HistoryMenuAddButton
 import org.sopt.mcdonalds.presentation.history.component.HistoryRecentBurgerItem
@@ -43,8 +47,10 @@ import org.sopt.mcdonalds.presentation.history.component.HistoryResultBar
 import org.sopt.mcdonalds.presentation.history.component.HistorySquareButton
 import org.sopt.mcdonalds.presentation.history.component.HistoryStoreBar
 import org.sopt.mcdonalds.presentation.history.component.HistoryTimeBar
+import org.sopt.mcdonalds.presentation.history.model.Cart
 import org.sopt.mcdonalds.presentation.history.state.HistoryContract.HistoryState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryRoute(
     onNavigateToMenuList: () -> Unit,
@@ -53,10 +59,22 @@ fun HistoryRoute(
     viewModel: HistoryViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val sheetState = rememberModalBottomSheetState()
+    var bottomSheetCart by remember { mutableStateOf<Cart?>(null) }
+
+    if (bottomSheetCart != null) {
+        CartEditBottomSheetScreen(
+            cart = bottomSheetCart!!,
+            onDismiss = { bottomSheetCart = null },
+            sheetState = sheetState
+        )
+    }
+
     HistoryScreen(
         uiState = uiState,
         onNavigateToMenuList = onNavigateToMenuList,
         onNavigateToOrder = onNavigateToOrder,
+        openBottomSheet = {it -> bottomSheetCart = it},
         increaseCount = viewModel::increaseCount,
         decreaseCount = viewModel::decreaseCount,
         modifier = modifier
@@ -69,6 +87,7 @@ private fun HistoryScreen(
     uiState: HistoryState,
     onNavigateToMenuList: () -> Unit,
     onNavigateToOrder: (Long) -> Unit,
+    openBottomSheet: (Cart) -> Unit,
     increaseCount: (Int) -> Unit,
     decreaseCount: (Int) -> Unit,
     modifier: Modifier = Modifier
@@ -139,7 +158,7 @@ private fun HistoryScreen(
                         onDecrementClick = {
                             decreaseCount(index)
                         },
-                        onEditClick = { /*TODO*/ },
+                        onEditClick = { openBottomSheet(cart) },
                         onDeleteClick = { /*구현 안함*/ }
                     )
                 }
@@ -213,6 +232,7 @@ private fun HistoryScreenPreview() {
             uiState = HistoryState(),
             onNavigateToMenuList = {},
             onNavigateToOrder = {},
+            openBottomSheet = {},
             increaseCount = {},
             decreaseCount = {},
             modifier = Modifier.background(McDonaldsTheme.colors.white)

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/HistoryScreen.kt
@@ -77,7 +77,7 @@ fun HistoryRoute(
         openBottomSheet = {it -> bottomSheetCart = it},
         increaseCount = viewModel::increaseCount,
         decreaseCount = viewModel::decreaseCount,
-        modifier = modifier
+        modifier = modifier.background(color = McDonaldsTheme.colors.white)
     )
 }
 

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/history/HistoryScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -74,7 +73,7 @@ fun HistoryRoute(
         uiState = uiState,
         onNavigateToMenuList = onNavigateToMenuList,
         onNavigateToOrder = onNavigateToOrder,
-        openBottomSheet = {it -> bottomSheetCart = it},
+        openBottomSheet = { it -> bottomSheetCart = it },
         increaseCount = viewModel::increaseCount,
         decreaseCount = viewModel::decreaseCount,
         modifier = modifier.background(color = McDonaldsTheme.colors.white)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,4 +57,7 @@
     <string name="order_drink_coke">코카 콜라</string>
 
     <string name="order_product_info">원산지, 영양성분 및 알레르기 정보</string>
+
+    <!-- bottom sheet   -->
+    <string name="bottom_sheet_confirm_button">변경 완료</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #28 

## Work Description ✏️
- 주문 내역에서 Edit Button 클릭 시 뜨는 BottomSheet UI 구현
- HistoryScreen과 BottomSheet 연결 및 로직 구현
- 세트/단품일때 UI 다름

## Screenshot 📸
https://github.com/user-attachments/assets/79a0257b-590e-439c-8d22-eefd31c24236


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
