### PR TITLE
[FEAT/#38] 카트 담기 api 연결

### DIFF
--- a/app/src/main/java/org/sopt/mcdonalds/core/network/BaseResponseWithNull.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/core/network/BaseResponseWithNull.kt
@@ -1,0 +1,15 @@
+package org.sopt.mcdonalds.core.network
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class BaseResponseWithNull(
+    @SerialName("code")
+    val code: Int,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: JsonElement? = null
+)

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/datasource/CartDataSource.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/datasource/CartDataSource.kt
@@ -1,0 +1,12 @@
+package org.sopt.mcdonalds.data.cart.datasource
+
+import org.sopt.mcdonalds.data.cart.dto.CartPostRequest
+import org.sopt.mcdonalds.data.cart.service.CartService
+import javax.inject.Inject
+
+class CartDataSource @Inject constructor(
+    private val cartService: CartService
+) {
+    suspend fun postCart(cartPostRequest: CartPostRequest) =
+        cartService.postCart(cartPostRequest)
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/di/RepositoryModule.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/di/RepositoryModule.kt
@@ -1,0 +1,19 @@
+package org.sopt.mcdonalds.data.cart.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.sopt.mcdonalds.data.cart.repository.CartRepositoryImpl
+import org.sopt.mcdonalds.domain.cart.repository.CartRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindCartRepository(
+        cartRepositoryImpl: CartRepositoryImpl,
+    ): CartRepository
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/di/ServiceModule.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/di/ServiceModule.kt
@@ -1,0 +1,19 @@
+package org.sopt.mcdonalds.data.cart.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.sopt.mcdonalds.data.cart.service.CartService
+import retrofit2.Retrofit
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+    @Provides
+    @Singleton
+    fun provideCartService(retrofit: Retrofit): CartService =
+        retrofit.create()
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/dto/CartPostRequest.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/dto/CartPostRequest.kt
@@ -1,0 +1,14 @@
+package org.sopt.mcdonalds.data.cart.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class CartPostRequest(
+    @SerialName("isSet")
+    val isSet: Boolean,
+    @SerialName("amount")
+    val amount: Int,
+    @SerialName("menuId")
+    val menuId: Long
+)

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/mapper/CartMapper.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/mapper/CartMapper.kt
@@ -5,7 +5,7 @@ import org.sopt.mcdonalds.domain.cart.model.CartDetail
 import org.sopt.mcdonalds.presentation.order.type.SetType
 
 fun CartDetail.toData() = CartPostRequest(
-    isSet = setType == SetType.SET,
+    isSet = isSet,
     amount = amount,
     menuId = menuId,
 )

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/mapper/CartMapper.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/mapper/CartMapper.kt
@@ -1,0 +1,11 @@
+package org.sopt.mcdonalds.data.cart.mapper
+
+import org.sopt.mcdonalds.data.cart.dto.CartPostRequest
+import org.sopt.mcdonalds.domain.cart.model.CartDetail
+import org.sopt.mcdonalds.presentation.order.type.SetType
+
+fun CartDetail.toData() = CartPostRequest(
+    isSet = setType == SetType.SET,
+    amount = amount,
+    menuId = menuId,
+)

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/repository/CartRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package org.sopt.mcdonalds.data.cart.repository
+
+import org.sopt.mcdonalds.data.cart.datasource.CartDataSource
+import org.sopt.mcdonalds.data.cart.mapper.toData
+import org.sopt.mcdonalds.domain.cart.model.CartDetail
+import org.sopt.mcdonalds.domain.cart.repository.CartRepository
+import javax.inject.Inject
+
+class CartRepositoryImpl @Inject constructor(
+    private val cartDataSource: CartDataSource
+) : CartRepository {
+    override suspend fun postCart(cartDetail: CartDetail): Result<Unit> =
+        runCatching {
+            cartDataSource.postCart(cartDetail.toData())
+        }
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/service/CartService.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/service/CartService.kt
@@ -1,0 +1,13 @@
+package org.sopt.mcdonalds.data.cart.service
+
+import org.sopt.mcdonalds.core.network.BaseResponse
+import org.sopt.mcdonalds.data.cart.dto.CartPostRequest
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface CartService {
+    @POST("cart")
+    suspend fun postCart(
+        @Body cartPostRequest: CartPostRequest
+    ): BaseResponse<Unit>
+}

--- a/app/src/main/java/org/sopt/mcdonalds/data/cart/service/CartService.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/data/cart/service/CartService.kt
@@ -1,6 +1,6 @@
 package org.sopt.mcdonalds.data.cart.service
 
-import org.sopt.mcdonalds.core.network.BaseResponse
+import org.sopt.mcdonalds.core.network.BaseResponseWithNull
 import org.sopt.mcdonalds.data.cart.dto.CartPostRequest
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -9,5 +9,5 @@ interface CartService {
     @POST("cart")
     suspend fun postCart(
         @Body cartPostRequest: CartPostRequest
-    ): BaseResponse<Unit>
+    ): BaseResponseWithNull
 }

--- a/app/src/main/java/org/sopt/mcdonalds/domain/cart/model/CartDetail.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/cart/model/CartDetail.kt
@@ -1,0 +1,9 @@
+package org.sopt.mcdonalds.domain.cart.model
+
+import org.sopt.mcdonalds.presentation.order.type.SetType
+
+data class CartDetail(
+    val setType: SetType,
+    val amount: Int,
+    val menuId: Long
+)

--- a/app/src/main/java/org/sopt/mcdonalds/domain/cart/model/CartDetail.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/cart/model/CartDetail.kt
@@ -1,9 +1,7 @@
 package org.sopt.mcdonalds.domain.cart.model
 
-import org.sopt.mcdonalds.presentation.order.type.SetType
-
 data class CartDetail(
-    val setType: SetType,
+    val isSet: Boolean,
     val amount: Int,
     val menuId: Long
 )

--- a/app/src/main/java/org/sopt/mcdonalds/domain/cart/repository/CartRepository.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/cart/repository/CartRepository.kt
@@ -1,8 +1,7 @@
 package org.sopt.mcdonalds.domain.cart.repository
 
-import org.sopt.mcdonalds.core.network.BaseResponse
 import org.sopt.mcdonalds.domain.cart.model.CartDetail
 
 interface CartRepository {
-    suspend fun postCart(cartDetail: CartDetail): Result<BaseResponse<Unit>>
+    suspend fun postCart(cartDetail: CartDetail): Result<Unit>
 }

--- a/app/src/main/java/org/sopt/mcdonalds/domain/cart/repository/CartRepository.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/cart/repository/CartRepository.kt
@@ -1,0 +1,8 @@
+package org.sopt.mcdonalds.domain.cart.repository
+
+import org.sopt.mcdonalds.core.network.BaseResponse
+import org.sopt.mcdonalds.domain.cart.model.CartDetail
+
+interface CartRepository {
+    suspend fun postCart(cartDetail: CartDetail): Result<BaseResponse<Unit>>
+}

--- a/app/src/main/java/org/sopt/mcdonalds/domain/cart/usecase/PostCartUseCase.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/domain/cart/usecase/PostCartUseCase.kt
@@ -1,0 +1,11 @@
+package org.sopt.mcdonalds.domain.cart.usecase
+
+import org.sopt.mcdonalds.domain.cart.model.CartDetail
+import org.sopt.mcdonalds.domain.cart.repository.CartRepository
+import javax.inject.Inject
+
+class PostCartUseCase @Inject constructor(
+    private val cartRepository: CartRepository
+) {
+    suspend operator fun invoke(cartDetail: CartDetail) = cartRepository.postCart(cartDetail)
+}

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
@@ -62,6 +62,7 @@ private fun MainNavHost(
         orderGraph(
             onNavigateToUp = navController::navigateUp,
             onNavigateToHistory = { /* TODO */ },
+            onNavigateToMenuList = navController::navigateToMenuList,
             modifier = modifier,
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.rememberNavController
 import org.sopt.mcdonalds.presentation.history.navigation.historyGraph
 import org.sopt.mcdonalds.presentation.menu.navigation.menuListGraph
 import org.sopt.mcdonalds.presentation.menu.navigation.navigateToMenuList
+import org.sopt.mcdonalds.presentation.order.navigation.navigateToOrder
 import org.sopt.mcdonalds.presentation.order.navigation.orderGraph
 import org.sopt.mcdonalds.presentation.store.navigation.Store
 import org.sopt.mcdonalds.presentation.store.navigation.storeGraph
@@ -49,7 +50,9 @@ private fun MainNavHost(
 
         menuListGraph(
             onNavigateToUp = navController::navigateUp,
-            onNavigateToOrder = { /* TODO */ },
+            onNavigateToOrder = {
+                navController.navigateToOrder(it)
+            },
             modifier = modifier
         )
 

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/main/MainScreen.kt
@@ -10,9 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
 import org.sopt.mcdonalds.presentation.history.navigation.historyGraph
 import org.sopt.mcdonalds.presentation.menu.navigation.menuListGraph
 import org.sopt.mcdonalds.presentation.menu.navigation.navigateToMenuList
+import org.sopt.mcdonalds.presentation.order.navigation.Order
 import org.sopt.mcdonalds.presentation.order.navigation.navigateToOrder
 import org.sopt.mcdonalds.presentation.order.navigation.orderGraph
 import org.sopt.mcdonalds.presentation.store.navigation.Store
@@ -65,7 +67,14 @@ private fun MainNavHost(
         orderGraph(
             onNavigateToUp = navController::navigateUp,
             onNavigateToHistory = { /* TODO */ },
-            onNavigateToMenuList = navController::navigateToMenuList,
+            onNavigateToMenuList = {
+                navController.navigateToMenuList(navOptions = navOptions {
+                    popUpTo<Order> {
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                })
+            },
             modifier = modifier,
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
@@ -136,7 +136,7 @@ private fun OrderScreen(
             Spacer(modifier = Modifier.height(24.dp))
             OrderBurgerDetailContainer(
                 name = uiState.menuDetail.name,
-                imageURL = uiState.menuDetail.singleImg,
+                imageId = R.drawable.img_burger_single,
                 ingredientList = persistentListOf(),
                 modifier = Modifier
                     .padding(horizontal = 20.dp)

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
@@ -35,11 +35,13 @@ import org.sopt.mcdonalds.core.designsystem.component.BorderedNumberIncrementer
 import org.sopt.mcdonalds.core.designsystem.component.DefaultTopBar
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+import org.sopt.mcdonalds.domain.menu.model.MenuDetail
 import org.sopt.mcdonalds.presentation.order.component.OrderBurgerDetailContainer
 import org.sopt.mcdonalds.presentation.order.component.OrderButton
 import org.sopt.mcdonalds.presentation.order.component.OrderSetSelectButton
 import org.sopt.mcdonalds.presentation.order.component.OrderSideDetailContainer
 import org.sopt.mcdonalds.presentation.order.model.Side
+import org.sopt.mcdonalds.presentation.order.state.OrderContract.OrderState
 import org.sopt.mcdonalds.presentation.order.type.SetType
 
 @Composable
@@ -52,9 +54,8 @@ fun OrderRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     OrderScreen(
-        setType = uiState.setType,
+        uiState = uiState,
         updateSetType = viewModel::updateSetType,
-        burgerCount = uiState.burgerCount,
         increaseBurgerCount = viewModel::increaseBurgerCount,
         decreaseBurgerCount = viewModel::decreaseBurgerCount,
         onBackClick = onBackClick,
@@ -66,9 +67,8 @@ fun OrderRoute(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun OrderScreen(
-    setType: SetType,
+    uiState: OrderState,
     updateSetType: (SetType) -> Unit,
-    burgerCount: Int,
     increaseBurgerCount: () -> Unit,
     decreaseBurgerCount: () -> Unit,
     onBackClick: () -> Unit,
@@ -91,7 +91,7 @@ private fun OrderScreen(
         ) {
             Spacer(modifier = Modifier.height(32.dp))
             Text(
-                text = "더블 1955® 버거",/* TODO: 나중에 수정 */
+                text = uiState.menuDetail.name,
                 style = McDonaldsTheme.typography.head34b,
                 color = McDonaldsTheme.colors.gray800,
                 textAlign = TextAlign.Start,
@@ -111,14 +111,14 @@ private fun OrderScreen(
                 OrderSetSelectButton(
                     text = stringResource(R.string.order_change_set),
                     price = "",
-                    isSelected = setType == SetType.SET,
+                    isSelected = uiState.setType == SetType.SET,
                     imageURL = "",
                     onSelect = { updateSetType(SetType.SET) }
                 )
                 OrderSetSelectButton(
                     text = stringResource(R.string.order_change_single),
                     price = "",
-                    isSelected = setType == SetType.SINGLE,
+                    isSelected = uiState.setType == SetType.SINGLE,
                     imageURL = "",
                     onSelect = { updateSetType(SetType.SINGLE) }
                 )
@@ -131,7 +131,7 @@ private fun OrderScreen(
                 modifier = Modifier
                     .padding(horizontal = 20.dp)
             )
-            if (setType == SetType.SET) {
+            if (uiState.setType == SetType.SET) {
                 Spacer(modifier = Modifier.height(16.dp))
                 OrderSideDetailContainer(
                     ingredientList = persistentListOf(),
@@ -171,9 +171,9 @@ private fun OrderScreen(
             }
             Spacer(modifier = Modifier.height(24.dp))
             BorderedNumberIncrementer(
-                count = burgerCount,
+                count = uiState.burgerCount,
                 onIncrementClick = { increaseBurgerCount() },
-                onDecrementClick = { if (burgerCount > 0) decreaseBurgerCount() },
+                onDecrementClick = { if (uiState.burgerCount > 0) decreaseBurgerCount() },
                 modifier = Modifier
                     .width(145.dp)
                     .height(40.dp)
@@ -228,9 +228,17 @@ private fun OrderScreenPreview(
     var count by remember { mutableStateOf(1) }
     MCDONALDSTheme {
         OrderScreen(
-            setType = SetType.SET,
+            uiState = OrderState(
+                menuDetail = MenuDetail(
+                    id = 0,
+                    name = "",
+                    singleImg = "",
+                    singlePrice = "",
+                    setImg = "",
+                    setPrice = ""
+                )
+            ),
             updateSetType = {},
-            burgerCount = count,
             increaseBurgerCount = { count++ },
             decreaseBurgerCount = { if (count > 0) count-- },
             onBackClick = {},

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
@@ -135,8 +135,8 @@ private fun OrderScreen(
             }
             Spacer(modifier = Modifier.height(24.dp))
             OrderBurgerDetailContainer(
-                name = "",
-                imageId = R.drawable.img_burger_single,
+                name = uiState.menuDetail.name,
+                imageURL = uiState.menuDetail.singleImg,
                 ingredientList = persistentListOf(),
                 modifier = Modifier
                     .padding(horizontal = 20.dp)

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
@@ -29,7 +29,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.core.designsystem.component.BorderedNumberIncrementer
@@ -42,7 +45,9 @@ import org.sopt.mcdonalds.presentation.order.component.OrderButton
 import org.sopt.mcdonalds.presentation.order.component.OrderSetSelectButton
 import org.sopt.mcdonalds.presentation.order.component.OrderSideDetailContainer
 import org.sopt.mcdonalds.presentation.order.model.Side
+import org.sopt.mcdonalds.presentation.order.state.OrderContract
 import org.sopt.mcdonalds.presentation.order.state.OrderContract.OrderState
+import org.sopt.mcdonalds.presentation.order.state.RouteDestination
 import org.sopt.mcdonalds.presentation.order.type.SetType
 
 @Composable
@@ -54,13 +59,16 @@ fun OrderRoute(
     viewModel: OrderViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    LaunchedEffect(Unit) {
-        viewModel.destination.collect { destination ->
-            when (destination) {
-                is RouteDestination.History -> onNavigateToHistory()
-                is RouteDestination.MenuList -> onNavigateToMenuList()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
+        viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
+            .collect { sideEffect ->
+                when (sideEffect.routeDestination) {
+                    is RouteDestination.History -> onNavigateToHistory()
+                    is RouteDestination.MenuList -> onNavigateToMenuList()
+                }
             }
-        }
     }
 
     OrderScreen(

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,10 +49,19 @@ import org.sopt.mcdonalds.presentation.order.type.SetType
 fun OrderRoute(
     onBackClick: () -> Unit,
     onNavigateToHistory: () -> Unit,
+    onNavigateToMenuList: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: OrderViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(Unit) {
+        viewModel.destination.collect { destination ->
+            when (destination) {
+                is RouteDestination.History -> onNavigateToHistory()
+                is RouteDestination.MenuList -> onNavigateToMenuList()
+            }
+        }
+    }
 
     OrderScreen(
         uiState = uiState,
@@ -59,7 +69,7 @@ fun OrderRoute(
         increaseBurgerCount = viewModel::increaseBurgerCount,
         decreaseBurgerCount = viewModel::decreaseBurgerCount,
         onBackClick = onBackClick,
-        onNavigateToHistory = onNavigateToHistory,
+        onClickOrderButton = viewModel::onClickOrderButton,
         modifier = modifier
     )
 }
@@ -72,7 +82,7 @@ private fun OrderScreen(
     increaseBurgerCount: () -> Unit,
     decreaseBurgerCount: () -> Unit,
     onBackClick: () -> Unit,
-    onNavigateToHistory: () -> Unit,
+    onClickOrderButton: (RouteDestination) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -109,18 +119,18 @@ private fun OrderScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 OrderSetSelectButton(
-                    text = stringResource(R.string.order_change_set),
-                    price = "",
-                    isSelected = uiState.setType == SetType.SET,
-                    imageURL = "",
-                    onSelect = { updateSetType(SetType.SET) }
+                    text = stringResource(R.string.order_change_single),
+                    price = uiState.menuDetail.singlePrice,
+                    isSelected = uiState.setType == SetType.SINGLE,
+                    imageURL = uiState.menuDetail.singleImg,
+                    onSelect = { updateSetType(SetType.SINGLE) }
                 )
                 OrderSetSelectButton(
-                    text = stringResource(R.string.order_change_single),
-                    price = "",
-                    isSelected = uiState.setType == SetType.SINGLE,
-                    imageURL = "",
-                    onSelect = { updateSetType(SetType.SINGLE) }
+                    text = stringResource(R.string.order_change_set),
+                    price = uiState.menuDetail.setPrice,
+                    isSelected = uiState.setType == SetType.SET,
+                    imageURL = uiState.menuDetail.setImg,
+                    onSelect = { updateSetType(SetType.SET) }
                 )
             }
             Spacer(modifier = Modifier.height(24.dp))
@@ -206,13 +216,13 @@ private fun OrderScreen(
             ) {
                 OrderButton(
                     text = stringResource(R.string.order_order_button),
-                    onClick = { /* TODO */ },
+                    onClick = { onClickOrderButton(RouteDestination.MenuList) },
                     color = McDonaldsTheme.colors.white,
                     modifier = Modifier.weight(1f)
                 )
                 OrderButton(
                     text = stringResource(R.string.order_cart_button),
-                    onClick = { /* TODO */ },
+                    onClick = { onClickOrderButton(RouteDestination.History) },
                     color = McDonaldsTheme.colors.yellow,
                     modifier = Modifier.weight(1f)
                 )
@@ -242,7 +252,7 @@ private fun OrderScreenPreview(
             increaseBurgerCount = { count++ },
             decreaseBurgerCount = { if (count > 0) count-- },
             onBackClick = {},
-            onNavigateToHistory = {},
+            onClickOrderButton = {},
             modifier = Modifier.background(McDonaldsTheme.colors.white)
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
@@ -88,7 +88,7 @@ class OrderViewModel @Inject constructor(
             Timber.d("post 요청 시작")
             postCartUseCase(
                 cartDetail = CartDetail(
-                    setType = uiState.value.setType,
+                    isSet = uiState.value.setType == SetType.SET,
                     amount = uiState.value.burgerCount,
                     menuId = uiState.value.menuDetail.id
                 )

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
@@ -18,6 +18,7 @@ import org.sopt.mcdonalds.domain.menu.usecase.GetMenuDetailUseCase
 import org.sopt.mcdonalds.presentation.order.navigation.Order
 import org.sopt.mcdonalds.presentation.order.state.OrderContract.OrderState
 import org.sopt.mcdonalds.presentation.order.type.SetType
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -82,6 +83,7 @@ class OrderViewModel @Inject constructor(
 
     fun onClickOrderButton(routeDestination: RouteDestination) {
         viewModelScope.launch {
+            Timber.d("post 요청 시작")
             postCartUseCase(
                 cartDetail = CartDetail(
                     setType = uiState.value.setType,
@@ -89,8 +91,10 @@ class OrderViewModel @Inject constructor(
                     menuId = uiState.value.menuDetail.id
                 )
             ).onSuccess {
+                Timber.d("post 요청 성공", routeDestination)
                 _destination.emit(routeDestination)
             }.onFailure {
+                Timber.e(it, "post 실패: ${it.message}")
                 // TODO
             }
         }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
@@ -16,7 +16,9 @@ import org.sopt.mcdonalds.domain.cart.usecase.PostCartUseCase
 import org.sopt.mcdonalds.domain.menu.model.MenuDetail
 import org.sopt.mcdonalds.domain.menu.usecase.GetMenuDetailUseCase
 import org.sopt.mcdonalds.presentation.order.navigation.Order
+import org.sopt.mcdonalds.presentation.order.state.OrderContract.OrderSideEffect
 import org.sopt.mcdonalds.presentation.order.state.OrderContract.OrderState
+import org.sopt.mcdonalds.presentation.order.state.RouteDestination
 import org.sopt.mcdonalds.presentation.order.type.SetType
 import timber.log.Timber
 import javax.inject.Inject
@@ -44,8 +46,8 @@ class OrderViewModel @Inject constructor(
     )
     val uiState = _uiState.asStateFlow()
 
-    private val _destination = MutableSharedFlow<RouteDestination>()
-    val destination = _destination.asSharedFlow()
+    private val _sideEffect = MutableSharedFlow<OrderSideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
 
     init {
         viewModelScope.launch {
@@ -92,16 +94,11 @@ class OrderViewModel @Inject constructor(
                 )
             ).onSuccess {
                 Timber.d("post 요청 성공", routeDestination)
-                _destination.emit(routeDestination)
+                _sideEffect.emit(OrderSideEffect(routeDestination))
             }.onFailure {
                 Timber.e(it, "post 실패: ${it.message}")
                 // TODO
             }
         }
     }
-}
-
-sealed class RouteDestination {
-    object MenuList : RouteDestination()
-    object History : RouteDestination()
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
@@ -43,8 +43,8 @@ class OrderViewModel @Inject constructor(
     )
     val uiState = _uiState.asStateFlow()
 
-    private val _result = MutableSharedFlow<OrderResult>()
-    val result = _result.asSharedFlow()
+    private val _destination = MutableSharedFlow<RouteDestination>()
+    val destination = _destination.asSharedFlow()
 
     init {
         viewModelScope.launch {
@@ -80,7 +80,7 @@ class OrderViewModel @Inject constructor(
         }
     }
 
-    fun onClickOrderButton() {
+    fun onClickOrderButton(routeDestination: RouteDestination) {
         viewModelScope.launch {
             postCartUseCase(
                 cartDetail = CartDetail(
@@ -89,15 +89,15 @@ class OrderViewModel @Inject constructor(
                     menuId = uiState.value.menuDetail.id
                 )
             ).onSuccess {
-                _result.emit(OrderResult.Success)
+                _destination.emit(routeDestination)
             }.onFailure {
-                _result.emit(OrderResult.Failure)
+                // TODO
             }
         }
     }
 }
 
-sealed class OrderResult {
-    object Success : OrderResult()
-    object Failure : OrderResult()
+sealed class RouteDestination {
+    object MenuList : RouteDestination()
+    object History : RouteDestination()
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/OrderViewModel.kt
@@ -2,11 +2,19 @@ package org.sopt.mcdonalds.presentation.order
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.sopt.mcdonalds.domain.cart.model.CartDetail
+import org.sopt.mcdonalds.domain.cart.usecase.PostCartUseCase
+import org.sopt.mcdonalds.domain.menu.model.MenuDetail
+import org.sopt.mcdonalds.domain.menu.usecase.GetMenuDetailUseCase
 import org.sopt.mcdonalds.presentation.order.navigation.Order
 import org.sopt.mcdonalds.presentation.order.state.OrderContract.OrderState
 import org.sopt.mcdonalds.presentation.order.type.SetType
@@ -14,16 +22,44 @@ import javax.inject.Inject
 
 @HiltViewModel
 class OrderViewModel @Inject constructor(
+    private val getMenuDetailUseCase: GetMenuDetailUseCase,
+    private val postCartUseCase: PostCartUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    val menuId = savedStateHandle.toRoute<Order>()
+    val menuId = savedStateHandle.toRoute<Order>().menuId
 
-    private val _uiState = MutableStateFlow(OrderState())
+    private val _uiState = MutableStateFlow(
+        OrderState(
+            menuDetail = MenuDetail(
+                id = menuId,
+                name = "",
+                singleImg = "",
+                singlePrice = "",
+                setImg = "",
+                setPrice = ""
+            )
+        )
+    )
     val uiState = _uiState.asStateFlow()
 
+    private val _result = MutableSharedFlow<OrderResult>()
+    val result = _result.asSharedFlow()
+
     init {
-        //  TODO: API
+        viewModelScope.launch {
+            getMenuDetailUseCase(menuId = menuId).onSuccess {
+                updateMenuDetail(menuDetail = it)
+            }.onFailure {
+                // TODO: API Called Failed
+            }
+        }
+    }
+
+    private fun updateMenuDetail(menuDetail: MenuDetail) {
+        _uiState.update {
+            it.copy(menuDetail = menuDetail)
+        }
     }
 
     fun increaseBurgerCount() {
@@ -44,7 +80,24 @@ class OrderViewModel @Inject constructor(
         }
     }
 
-    private fun postOrder() {
-//        TODO: API
+    fun onClickOrderButton() {
+        viewModelScope.launch {
+            postCartUseCase(
+                cartDetail = CartDetail(
+                    setType = uiState.value.setType,
+                    amount = uiState.value.burgerCount,
+                    menuId = uiState.value.menuDetail.id
+                )
+            ).onSuccess {
+                _result.emit(OrderResult.Success)
+            }.onFailure {
+                _result.emit(OrderResult.Failure)
+            }
+        }
     }
+}
+
+sealed class OrderResult {
+    object Success : OrderResult()
+    object Failure : OrderResult()
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderBurgerDetailContainer.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderBurgerDetailContainer.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
@@ -44,7 +45,7 @@ import org.sopt.mcdonalds.presentation.order.model.Ingredient
 @Composable
 fun OrderBurgerDetailContainer(
     name: String,
-    @DrawableRes imageId: Int,
+    imageURL: String,
     ingredientList: List<Ingredient>,
     modifier: Modifier = Modifier
 ) {
@@ -67,8 +68,8 @@ fun OrderBurgerDetailContainer(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start
         ) {
-            Image(
-                painter = painterResource(imageId),
+            AsyncImage(
+                model = imageURL,
                 contentDescription = null,
                 modifier = Modifier
                     .width(76.dp)
@@ -98,7 +99,7 @@ private fun OrderBurgerDetailContainerPreview() {
     MCDONALDSTheme {
         OrderBurgerDetailContainer(
             "더블 1955® 버거",
-            R.drawable.img_burger_single,
+            "",
             ingredientList = listOf(
                 Ingredient(
                     name = "양파",

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderBurgerDetailContainer.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderBurgerDetailContainer.kt
@@ -45,7 +45,7 @@ import org.sopt.mcdonalds.presentation.order.model.Ingredient
 @Composable
 fun OrderBurgerDetailContainer(
     name: String,
-    imageURL: String,
+    @DrawableRes imageId: Int,
     ingredientList: List<Ingredient>,
     modifier: Modifier = Modifier
 ) {
@@ -68,8 +68,8 @@ fun OrderBurgerDetailContainer(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start
         ) {
-            AsyncImage(
-                model = imageURL,
+            Image(
+                painter = painterResource(imageId),
                 contentDescription = null,
                 modifier = Modifier
                     .width(76.dp)
@@ -99,7 +99,7 @@ private fun OrderBurgerDetailContainerPreview() {
     MCDONALDSTheme {
         OrderBurgerDetailContainer(
             "더블 1955® 버거",
-            "",
+            R.drawable.img_burger_single,
             ingredientList = listOf(
                 Ingredient(
                     name = "양파",

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderButton.kt
@@ -20,6 +20,7 @@ import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
+import org.sopt.mcdonalds.presentation.order.RouteDestination
 
 /**
  * 더미 사용자 데이터를 보여주기 위한 컴포넌트

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderButton.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/component/OrderButton.kt
@@ -20,7 +20,6 @@ import org.sopt.mcdonalds.R
 import org.sopt.mcdonalds.core.common.util.NoRippleInteractionSource
 import org.sopt.mcdonalds.core.designsystem.theme.MCDONALDSTheme
 import org.sopt.mcdonalds.core.designsystem.theme.McDonaldsTheme
-import org.sopt.mcdonalds.presentation.order.RouteDestination
 
 /**
  * 더미 사용자 데이터를 보여주기 위한 컴포넌트

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/navigation/OrderNavigation.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/navigation/OrderNavigation.kt
@@ -16,12 +16,14 @@ fun NavController.navigateToOrder(menuId: Long, navOptions: NavOptions? = null) 
 fun NavGraphBuilder.orderGraph(
     onNavigateToUp: () -> Unit,
     onNavigateToHistory: () -> Unit,
+    onNavigateToMenuList: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     composable<Order> {
         OrderRoute(
             onBackClick = onNavigateToUp,
             onNavigateToHistory = onNavigateToHistory,
+            onNavigateToMenuList = onNavigateToMenuList,
             modifier = modifier
         )
     }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/state/OrderContract.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/state/OrderContract.kt
@@ -9,4 +9,13 @@ class OrderContract {
         val burgerCount: Int = 1,
         val setType: SetType = SetType.SET,
     )
+
+    data class OrderSideEffect(
+        val routeDestination: RouteDestination
+    )
+}
+
+sealed class RouteDestination {
+    object MenuList : RouteDestination()
+    object History : RouteDestination()
 }

--- a/app/src/main/java/org/sopt/mcdonalds/presentation/order/state/OrderContract.kt
+++ b/app/src/main/java/org/sopt/mcdonalds/presentation/order/state/OrderContract.kt
@@ -1,10 +1,12 @@
 package org.sopt.mcdonalds.presentation.order.state
 
+import org.sopt.mcdonalds.domain.menu.model.MenuDetail
 import org.sopt.mcdonalds.presentation.order.type.SetType
 
 class OrderContract {
     data class OrderState(
+        val menuDetail: MenuDetail,
         val burgerCount: Int = 1,
-        val setType: SetType = SetType.SET
+        val setType: SetType = SetType.SET,
     )
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #38 

## Work Description ✏️
- 카트담기 api 연결
- 바로 주문하기의 경우 메뉴리스트로 넘어갈 때 popUpTo와 singleTop을 navOption에 추가
- data에 null값 들어오는 BaseResponse 추가

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] BurgerDetailContainer의 인자를 수정해야하는데 History의 BottomSheet에서도 쓰여서 우선 나중에 하겠습니다.

## To Reviewers 📢